### PR TITLE
test: Add GBM sanity check CI tests and mark cornerflow as slow

### DIFF
--- a/src/pydrex/data/drexF90/olA_D1E4_dt50_X0_L5.scsv
+++ b/src/pydrex/data/drexF90/olA_D1E4_dt50_X0_L5.scsv
@@ -4,7 +4,7 @@
 # The flow field is a static simple shear and the aggregate starts with random (i.e. isotropically distributed) grain orientations.
 # Data is averaged from 500 runs of the Fortran DRex for each GBM case, with
 # - gbs_threshold (X) = 0
-# - nucleation_efficiency (λ) = 5
+# - nucleation_efficiency (λ*) = 5
 # and a timestep of 50 with a strain rate of 1e-4 (final accumulated strain is 1).
 
 schema:

--- a/tests/test_corner_flow_2d.py
+++ b/tests/test_corner_flow_2d.py
@@ -46,6 +46,7 @@ import time
 
 import numba as nb
 import numpy as np
+import pytest
 from numpy import testing as nt
 from scipy.spatial.transform import Rotation
 
@@ -79,6 +80,7 @@ def get_velocity_gradient(x, z, plate_velocity):
 class TestOlivineA:
     """Tests for pure A-type olivine polycrystals in 2D corner flows."""
 
+    @pytest.mark.slow
     def test_corner_prescribed_init_isotropic(
         self,
         params_Kaminski2001_fig5_shortdash,

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -14,7 +14,6 @@ from pydrex import diagnostics as _diagnostics
 from pydrex import io as _io
 from pydrex import logger as _log
 from pydrex import minerals as _minerals
-from pydrex import stats as _stats
 from pydrex import utils as _utils
 from pydrex import velocity_gradients as _dv
 from pydrex import visualisation as _vis
@@ -167,6 +166,51 @@ class TestOlivineA:
             45 + _utils.remove_nans(data.angle_X0d4),
         )
         return [cs_X0(strains), cs_X0d2(strains), cs_X0d4(strains)]
+
+    def test_zero_recrystallisation(self, seed):
+        """Check that M*=0 is a reliable switch to turn off recrystallisation."""
+        params = _io.DEFAULT_PARAMS
+        params["gbm_mobility"] = 0
+        strain_rate = 1
+        timestamps = np.linspace(0, 1, 25)  # Solve until D₀t=1 (tensorial strain).
+        shear_direction = [0, 1, 0]
+        get_velocity_gradient = _dv.simple_shear_2d("Y", "X", strain_rate)
+        mineral, _ = self.run(
+            params,
+            timestamps,
+            strain_rate,
+            get_velocity_gradient,
+            shear_direction,
+            seed=seed,
+        )
+        for fractions in mineral.fractions[1:]:
+            nt.assert_allclose(fractions, mineral.fractions[0], atol=1e-15, rtol=0)
+
+    @pytest.mark.parametrize("gbm_mobility", [50, 100, 150])
+    def test_grainsize_median(self, seed, gbm_mobility):
+        """Check that M*={50,100,150}, λ*=5 causes decreasing grain size median."""
+        params = _io.DEFAULT_PARAMS
+        params["gbm_mobility"] = gbm_mobility
+        params["nucleation_efficiency"] = 5
+        strain_rate = 1
+        timestamps = np.linspace(0, 1, 25)  # Solve until D₀t=1 (tensorial strain).
+        n_timestamps = len(timestamps)
+        shear_direction = [0, 1, 0]
+        get_velocity_gradient = _dv.simple_shear_2d("Y", "X", strain_rate)
+        mineral, _ = self.run(
+            params,
+            timestamps,
+            strain_rate,
+            get_velocity_gradient,
+            shear_direction,
+            seed=seed,
+        )
+        medians = np.empty(n_timestamps)
+        for i, fractions in enumerate(mineral.fractions):
+            medians[i] = np.median(fractions)
+
+        # The first diff is positive (~1e-6) before nucleation sets in.
+        nt.assert_array_less(np.diff(medians)[1:], np.full(n_timestamps - 2, 0))
 
     @pytest.mark.slow
     @pytest.mark.parametrize("gbs_threshold", [0, 0.2, 0.4])
@@ -467,161 +511,3 @@ class TestOlivineA:
             atol=1.5,
             rtol=0,
         )
-
-        # TODO: Make this into a separate non-ensemble test.
-        # # Check that M*=0 doesn't affect grain sizes.
-        # _log.info("checking grain sizes...")
-        # for i, time in enumerate(timestamps):
-        #     nt.assert_allclose(
-        #         minerals[0].fractions[i],
-        #         np.full(params["number_of_grains"], 1 / params["number_of_grains"]),
-        #     )
-
-        # TODO: Make this into a separate non-ensemble test.
-        # # Check that GBM causes decreasing grain size median.
-        # assert np.all(
-        #     np.array(
-        #         [
-        #             np.median(m.fractions[halfway])
-        #             - np.median(minerals[i].fractions[halfway])
-        #             for i, m in enumerate(minerals[:-1], start=1)
-        #         ]
-        #     )
-        #     > 0
-        # )
-
-    def test_boundary_sliding(self, seed, ncpus, outdir):
-        """Test that the grain boundary sliding parameter has an effect."""
-        strain_rate = 1.0
-        shear_direction = [1, 0, 0]  # Used to calculate the angular diagnostics.
-        get_velocity_gradient = _dv.simple_shear_2d("X", "Z", strain_rate)
-        timestamps = np.linspace(0, 2.5, 251)  # Solve until D₀t=2.5 ('shear' γ=5).
-        i_strain_200p = 100  # Index of 50% strain.
-        params = _io.DEFAULT_PARAMS
-        gbs_thresholds = (0, 0.2, 0.4, 0.6)  # Must be in ascending order.
-        markers = (".", "*", "d", "s")
-        angles = np.empty((len(gbs_thresholds), len(timestamps)))
-        symmetry = np.empty_like(angles)
-        θ_fse = np.empty_like(angles)
-        minerals = []
-
-        optional_logging = cl.nullcontext()
-        if outdir is not None:
-            out_basepath = f"{outdir}/{SUBDIR}/{self.class_id}_sliding"
-            optional_logging = _log.logfile_enable(f"{out_basepath}.log")
-            labels = []
-
-        with optional_logging:
-            for f, gbs_threshold in enumerate(gbs_thresholds):
-                params["gbs_threshold"] = gbs_threshold
-                mineral, fse_angles = self.run(
-                    params,
-                    timestamps,
-                    strain_rate,
-                    get_velocity_gradient,
-                    shear_direction,
-                    seed=seed,
-                    return_fse=True,
-                )
-                minerals.append(mineral)
-                angles[f] = [
-                    _diagnostics.smallest_angle(v, shear_direction)
-                    for v in _diagnostics.elasticity_components(
-                        _minerals.voigt_averages([mineral], params)
-                    )["hexagonal_axis"]
-                ]
-                symmetry[f] = [
-                    _diagnostics.symmetry(
-                        o, axis=_minerals.OLIVINE_PRIMARY_AXIS[mineral.fabric]
-                    )[
-                        0
-                    ]  # P_[100] diagnostic.
-                    for o in _stats.resample_orientations(
-                        mineral.orientations,
-                        mineral.fractions,
-                        n_samples=1000,
-                        seed=seed,
-                    )[0]
-                ]
-                θ_fse[f] = fse_angles
-                if outdir is not None:
-                    labels.append(f"$f_{{gbs}}$ = {params['gbs_threshold']}")
-
-        if outdir is not None:
-            strains = timestamps * strain_rate
-            fig, ax, colors = _vis.alignment(
-                None,
-                strains,
-                angles,
-                markers,
-                labels,
-                θ_max=60,
-                θ_fse=np.mean(θ_fse, axis=0),
-            )
-            fig.savefig(_io.resolve_path(f"{out_basepath}.png"))
-            # Save mineral for the X=0.2 run, for polefigs.
-            minerals[2].save(f"{out_basepath}.npz")
-
-        # Check that GBS sets an upper bound on P_[100].
-        _log.info("checking degree of [100] point symmetry...")
-        nt.assert_allclose(
-            np.full(len(symmetry[0][i_strain_200p:]), 0.0),
-            symmetry[0][i_strain_200p:] - 0.95,
-            atol=0.9,
-            rtol=0,
-        )
-        nt.assert_allclose(
-            np.full(len(symmetry[1][i_strain_200p:]), 0.0),
-            symmetry[1][i_strain_200p:] - 0.775,
-            atol=0.9,
-            rtol=0,
-        )
-        nt.assert_allclose(
-            np.full(len(symmetry[2][i_strain_200p:]), 0.0),
-            symmetry[2][i_strain_200p:] - 0.61,
-            atol=0.9,
-            rtol=0,
-        )
-        nt.assert_allclose(
-            np.full(len(symmetry[3][i_strain_200p:]), 0.0),
-            symmetry[3][i_strain_200p:] - 0.44,
-            atol=0.9,
-            rtol=0,
-        )
-        # Check that angles always reach within 7.5° of the shear direction.
-        _log.info("checking grain orientations...")
-        for θ in angles:
-            nt.assert_allclose(
-                np.full(len(θ[i_strain_200p:]), 0.0),
-                θ[i_strain_200p:],
-                atol=7.5,
-                rtol=0,
-            )
-
-    @pytest.mark.slow
-    def test_ngrains(self, seed, outdir):
-        """Test that solvers work up to 10000 grains."""
-        shear_direction = [0, 1, 0]
-        strain_rate = 1.0
-        get_velocity_gradient = _dv.simple_shear_2d("Y", "X", strain_rate)
-        timestamps = np.linspace(0, 1, 201)  # Solve until D₀t=1 ('shear' γ=2).
-        params = _io.DEFAULT_PARAMS
-        grain_counts = (100, 1000, 2000, 5000, 10000)
-
-        optional_logging = cl.nullcontext()
-        if outdir is not None:
-            out_basepath = f"{outdir}/{SUBDIR}/{self.class_id}_ngrains"
-            optional_logging = _log.logfile_enable(f"{out_basepath}.log")
-
-        with optional_logging:
-            for i, N in enumerate(grain_counts):
-                params["number_of_grains"] = N
-                self.run(
-                    params,
-                    timestamps,
-                    strain_rate,
-                    get_velocity_gradient,
-                    shear_direction,
-                    seed=seed,
-                    return_fse=True,
-                )


### PR DESCRIPTION
Also removed the redundant GBS ensemble (GBS example is covered by the big `test_dvdx_ensemble` example). Removed basic n_grains test which didn't have asserts, to be replaced with a more complete convergence test.