### PR TITLE
fix: Minor fixes to core.py and minerals.py

### DIFF
--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -93,7 +93,7 @@ def get_crss(phase, fabric):
     elif phase == MineralPhase.enstatite:
         if fabric == MineralFabric.enstatite_AB:
             return np.array([np.inf, np.inf, np.inf, 1])
-            raise ValueError("unsupported enstatite fabric")
+        raise ValueError("unsupported enstatite fabric")
     raise ValueError("phase must be a valid `MineralPhase`")
 
 
@@ -425,10 +425,6 @@ def _get_rotation_and_strain(
         deformation_rate,
         slip_rate_softest,
     )
-
-    if phase == MineralPhase.enstatite:
-        slip_rate_softest /= crss[slip_indices[-1]] ** stress_exponent
-
     strain_energy = _get_strain_energy(
         crss,
         slip_rates,

--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -362,6 +362,13 @@ class Mineral:
             #     velocity_gradient.flatten(),
             # )
 
+            if self.phase == _core.MineralPhase.olivine:
+                volume_fraction = config["olivine_fraction"]
+            elif self.phase == _core.MineralPhase.enstatite:
+                volume_fraction = config["enstatite_fraction"]
+            else:
+                assert False  # Should never happen.
+
             strain_rate = (velocity_gradient + velocity_gradient.transpose()) / 2
             strain_rate_max = np.abs(la.eigvalsh(strain_rate)).max()
             deformation_gradient, orientations, fractions = extract_vars(y)
@@ -436,13 +443,6 @@ class Mineral:
                 + " You must provide a callable with signature f(t)"
                 + " that returns a 3-component array."
             )
-
-        if self.phase == _core.MineralPhase.olivine:
-            volume_fraction = config["olivine_fraction"]
-        elif self.phase == _core.MineralPhase.enstatite:
-            volume_fraction = config["enstatite_fraction"]
-        else:
-            assert False  # Should never happen.
 
         y_start = np.hstack(
             (


### PR DESCRIPTION
- fixed incorrect indentation for raising an error on unknown enstatite fabric input
- removed redundant enstatite slip rate multiplication factor (it always evaluates to 1 anyway becuase the single active slip system of enstatite always has τ∗=1 by definition; this is also the case for the Fortran code actually)
- put enstatite/olivine volume fraction switch inside the LSODA right hand side solve, to make the code read in a more intuitive execution order and not use inherited magic variables from the enclosing scope