### PR TITLE
test: Add reworked 2D cornerflow example

### DIFF
--- a/src/pydrex/diagnostics.py
+++ b/src/pydrex/diagnostics.py
@@ -289,7 +289,7 @@ def misorientation_indices(
     if ncpus is None:
         ncpus = len(os.sched_getaffinity(0)) - 1
     with Pool(processes=ncpus) as pool:
-        for i, out in enumerate(pool.imap_unordered(_run, orientation_stack)):
+        for i, out in enumerate(pool.map(_run, orientation_stack)):
             m_indices[i] = out
     return m_indices
 

--- a/src/pydrex/geometry.py
+++ b/src/pydrex/geometry.py
@@ -188,7 +188,8 @@ def poles(orientations, ref_axes="xz", hkl=[1, 0, 0]):
     horizontal and vertical axes of pole figures used to plot the directions.
 
     """
-    upward_axes = (set("xyz") - set(ref_axes)).pop()
+    _ref_axes = ref_axes.lower()
+    upward_axes = (set("xyz") - set(_ref_axes)).pop()
     axes_map = {"x": 0, "y": 1, "z": 2}
 
     # Get directions in the right-handed frame.
@@ -198,8 +199,8 @@ def poles(orientations, ref_axes="xz", hkl=[1, 0, 0]):
 
     # Rotate into the chosen reference frame.
     zvals = directions[:, axes_map[upward_axes]]
-    yvals = directions[:, axes_map[ref_axes[1]]]
-    xvals = directions[:, axes_map[ref_axes[0]]]
+    yvals = directions[:, axes_map[_ref_axes[1]]]
+    xvals = directions[:, axes_map[_ref_axes[0]]]
     return xvals, yvals, zvals
 
 

--- a/src/pydrex/velocity.py
+++ b/src/pydrex/velocity.py
@@ -1,4 +1,10 @@
-"""> PyDRex: Steady-state solutions of velocity (gradients) for various flows."""
+"""> PyDRex: Steady-state solutions of velocity (gradients) for various flows.
+
+For the sake of consistency, all callables returned from methods in this module expect a
+3D position vector as input. They also return 3D tensors in all cases. This means they
+can be directly used as arguments to e.g. `pydrex.minerals.Mineral.update_orientations`.
+
+"""
 import functools as ft
 
 import numba as nb
@@ -45,10 +51,34 @@ def _cell_2d(x, horizontal=0, vertical=2, velocity_edge=1):
     return v
 
 
+@nb.njit(fastmath=True)
+def _corner_2d(x, horizontal=0, vertical=2, plate_speed=1):
+    h = x[horizontal]
+    v = x[vertical]
+    out = np.zeros(3)
+    prefactor = 2 * plate_speed / np.pi
+    out[horizontal] = prefactor * (np.arctan2(h, -v) + h * v / (h**2 + v**2))
+    out[vertical] = prefactor * v**2 / (h**2 + v**2)
+    return out
+
+
+@nb.njit(fastmath=True)
+def _corner_2d_grad(x, horizontal=0, vertical=2, plate_speed=1):
+    h = x[horizontal]
+    v = x[vertical]
+    grad_v = np.zeros((3, 3))
+    prefactor = 4 * plate_speed / (np.pi * (h**2 + v**2)**2)
+    grad_v[horizontal, horizontal] = -(h**2) * v
+    grad_v[horizontal, vertical] = h**3
+    grad_v[vertical, horizontal] = -h * v**2
+    grad_v[vertical, vertical] = h**2 * v
+    return prefactor * grad_v
+
+
 def simple_shear_2d(direction, deformation_plane, strain_rate):
     """Return simple shear velocity and velocity gradient callables.
 
-    The returned callables have signature f(x) where x is a position vector.
+    The returned callables have signature f(x) where x is a 3D position vector.
 
     Args:
     - `direction` (one of {"X", "Y", "Z"}) — velocity vector direction
@@ -93,9 +123,16 @@ def simple_shear_2d(direction, deformation_plane, strain_rate):
 
 
 def cell_2d(horizontal, vertical, velocity_edge):
-    """Return velocity and velocity gradient callable for a steady-state 2D Stokes cell.
+    r"""Return velocity and velocity gradient callable for a steady-state 2D Stokes cell.
 
-    The returned callables have signature f(x) where x is a position vector.
+    The velocity field is defined by:
+    $$
+    \bm{u} = \cos(π x/2)\sin(π x/2) \bm{\hat{h}} - \sin(π x/2)\cos(π x/2) \bm{\hat{v}}
+    $$
+    where $\bm{\hat{h}}$ and $\bm{\hat{v}}$ are unit vectors in the chosen horizontal
+    and vertical directions, respectively.
+
+    The returned callables have signature f(x) where x is a 3D position vector.
 
     Args:
     - `horizontal` (one of {"X", "Y", "Z"}) — horizontal direction
@@ -135,5 +172,89 @@ def cell_2d(horizontal, vertical, velocity_edge):
             horizontal=_geometry[0],
             vertical=_geometry[1],
             velocity_edge=velocity_edge,
+        ),
+    )
+
+
+def corner_2d(horizontal, vertical, plate_speed):
+    r"""Return velocity and velocity gradient callable for a steady-state 2D Stokes cell.
+
+    The velocity field is defined by:
+    $$
+    \bm{u} = \frac{dr}{dt} \bm{\hat{r}} + r \frac{dθ}{dt} \bm{\hat{θ}}
+    = \frac{2 U}{π}(θ\sinθ - \cosθ) ⋅ \bm{\hat{r}} + \frac{2 U}{π}θ\cosθ ⋅ \bm{\hat{θ}}
+    $$
+    where $θ = 0$ points vertically downwards along the ridge axis
+    and $θ = π/2$ points along the surface. $U$ is the half spreading velocity.
+    Streamlines for the flow obey:
+    $$
+    ψ = \frac{2 U r}{π}θ\cosθ
+    $$
+    and are related to the velocity through:
+    $$
+    \bm{u} = -\frac{1}{r} ⋅ \frac{dψ}{dθ} ⋅ \bm{\hat{r}} + \frac{dψ}{dr}\bm{\hat{θ}}
+    $$
+    Conversion to Cartesian ($x,y,z$) coordinates yields:
+    $$
+    \bm{u} = \frac{2U}{π} \left[
+    \tan^{-1}\left(\frac{x}{-z}\right) + \frac{xz}{x^{2} + z^{2}} \right] \bm{\hat{x}} +
+    \frac{2U}{π} \frac{z^{2}}{x^{2} + z^{2}} \bm{\hat{z}}
+    $$
+    where
+    \begin{align\*}
+    x &= r \sinθ \cr
+    z &= -r \cosθ
+    \end{align\*}
+    and the velocity gradient is:
+    $$
+    L = \frac{4 U}{π{(x^{2}+z^{2})}^{2}} ⋅
+    \begin{bmatrix}
+        -x^{2}z & 0 & x^{3} \cr
+        0 & 0 & 0 \cr
+        -xz^{2} & 0 & x^{2}z
+    \end{bmatrix}
+    $$
+    See also Fig. 5 in [Kaminski & Ribe, 2002](https://doi.org/10.1029/2001GC000222).
+
+    The returned callables have signature f(x) where x is a 3D position vector.
+
+    Args:
+    - `horizontal` (one of {"X", "Y", "Z"}) — horizontal direction
+    - `vertical` (one of {"X", "Y", "Z"}) — vertical direction
+    - `plate_speed` (float) — speed of the “plate” i.e. upper boundary
+
+    """
+    geometry = (horizontal, vertical)
+    match geometry:
+        case ("X", "Y"):
+            _geometry = (0, 1)
+        case ("X", "Z"):
+            _geometry = (0, 2)
+        case ("Y", "X"):
+            _geometry = (1, 0)
+        case ("Y", "Z"):
+            _geometry = (1, 2)
+        case ("Z", "X"):
+            _geometry = (2, 0)
+        case ("Z", "Y"):
+            _geometry = (2, 1)
+        case _:
+            raise ValueError(
+                "unsupported convection cell geometry with"
+                + f" horizontal = {horizontal}, vertical = {vertical}"
+            )
+
+    return (
+        ft.partial(
+            _corner_2d,
+            horizontal=_geometry[0],
+            vertical=_geometry[1],
+            plate_speed=plate_speed,
+        ),
+        ft.partial(
+            _corner_2d_grad,
+            horizontal=_geometry[0],
+            vertical=_geometry[1],
+            plate_speed=plate_speed,
         ),
     )

--- a/src/pydrex/velocity.py
+++ b/src/pydrex/velocity.py
@@ -55,6 +55,8 @@ def _cell_2d(x, horizontal=0, vertical=2, velocity_edge=1):
 def _corner_2d(x, horizontal=0, vertical=2, plate_speed=1):
     h = x[horizontal]
     v = x[vertical]
+    if np.abs(h) < 1e-15 and np.abs(v) < 1e-15:
+        return np.full(3, np.nan)
     out = np.zeros(3)
     prefactor = 2 * plate_speed / np.pi
     out[horizontal] = prefactor * (np.arctan2(h, -v) + h * v / (h**2 + v**2))
@@ -66,6 +68,8 @@ def _corner_2d(x, horizontal=0, vertical=2, plate_speed=1):
 def _corner_2d_grad(x, horizontal=0, vertical=2, plate_speed=1):
     h = x[horizontal]
     v = x[vertical]
+    if np.abs(h) < 1e-15 and np.abs(v) < 1e-15:
+        return np.full((3, 3), np.nan)
     grad_v = np.zeros((3, 3))
     prefactor = 4 * plate_speed / (np.pi * (h**2 + v**2)**2)
     grad_v[horizontal, horizontal] = -(h**2) * v
@@ -123,7 +127,7 @@ def simple_shear_2d(direction, deformation_plane, strain_rate):
 
 
 def cell_2d(horizontal, vertical, velocity_edge):
-    r"""Return velocity and velocity gradient callable for a steady-state 2D Stokes cell.
+    r"""Get velocity and velocity gradient callables for a steady-state 2D Stokes cell.
 
     The velocity field is defined by:
     $$
@@ -177,7 +181,7 @@ def cell_2d(horizontal, vertical, velocity_edge):
 
 
 def corner_2d(horizontal, vertical, plate_speed):
-    r"""Return velocity and velocity gradient callable for a steady-state 2D Stokes cell.
+    r"""Get velocity and velocity gradient callables for a steady-state 2D corner flow.
 
     The velocity field is defined by:
     $$

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -146,8 +146,12 @@ def pathline_box2d(
     min_coords,
     max_coords,
     resolution,
-    scale=1,
+    scale=None,
+    aspect="equal",
     cmap=cmc.batlow,
+    cpo_vectors=None,
+    cpo_strengths=None,
+    tick_formatter=lambda x, pos: f"{x/1e3:.1f} km",
 ):
     """Plot pathlines and velocity arrows for a 2D box domain.
 
@@ -156,16 +160,21 @@ def pathline_box2d(
     Args:
     - `get_velocity` (callable) — object with call signature f(x) that returns
       the 3D velocity vector at a given 3D position vector
-    - `ref_axes` (two letters from {"X", "Y", "Z"}) — labels for the horizontal and
+    - `ref_axes` (two letters from {"x", "y", "z"}) — labels for the horizontal and
       vertical axes (these also define the projection for the 3D velocity/position)
     - `colors` (array) — monotonic values along a representative pathline in the flow
     - `positions` (Nx3 array) — 3D position vectors along the same pathline
     - `min_coords` (array) — 2D coordinates of the lower left corner of the domain
     - `max_coords` (array) — 2D coordinates of the upper right corner of the domain
     - `resolution` (array) — 2D resolution of the velocity arrow grid (i.e. number of
-      grid points in the horizontal and vertical directions)
+      grid points in the horizontal and vertical directions) which can be set to None to
+      prevent drawing velocity vectors
     - `scale` (float, optional) — scale factor for the velocity arrows
+    - `aspect` (str|float, optional) — see `matplotlib.axes.Axes.set_aspect`
     - `cmap` (Matplotlib color map, optional) — color map for `colors`
+    - `cpo_vectors` (array, optional) — vectors to plot as bars at pathline locations
+    - `cpo_strengths` (array, optional) — strengths used to scale the cpo bars
+    - `tick_formatter` (callable, optional) — function used to format tick labels
 
     Returns the figure handle, the axes handle, the quiver collection (velocities) and
     the scatter collection (pathline).
@@ -179,47 +188,68 @@ def pathline_box2d(
     x_max, y_max = max_coords
     ax.set_xlim((x_min, x_max))
     ax.set_ylim((y_min, y_max))
+    ax.set_aspect(aspect)
+    ax.xaxis.set_major_formatter(tick_formatter)
+    ax.yaxis.set_major_formatter(tick_formatter)
 
-    x_res, y_res = resolution
-    if (x_res/y_res - 1) < 0.3:
-        ax.set_aspect("equal")
-    X = np.linspace(x_min, x_max, x_res)
-    Y = np.linspace(y_min, y_max, y_res)
-    X_grid, Y_grid = np.meshgrid(X, Y)
+    _ref_axes = ref_axes.lower()
+    axes_map = {"x": 0, "y": 1, "z": 2}
+    horizontal = axes_map[_ref_axes[0]]
+    vertical = axes_map[_ref_axes[1]]
 
-    dummy_dimension = next(iter({"X", "Y", "Z"} - {ref_axes[0], ref_axes[1]}))
-    U = np.zeros_like(X_grid.ravel())
-    V = np.zeros_like(Y_grid.ravel())
-    match dummy_dimension:
-        case "X":
-            P = np.asarray([[p[1], p[2]] for p in positions])
-            for i, (x, y) in enumerate(zip(X_grid.ravel(), Y_grid.ravel())):
-                v3d = get_velocity(np.asarray([0, x, y]))
-                U[i] = v3d[1]
-                V[i] = v3d[2]
-        case "Y":
-            P = np.asarray([[p[0], p[2]] for p in positions])
-            for i, (x, y) in enumerate(zip(X_grid.ravel(), Y_grid.ravel())):
-                v3d = get_velocity(np.asarray([x, 0, y]))
-                U[i] = v3d[0]
-                V[i] = v3d[2]
-        case "Z":
-            P = np.asarray([[p[0], p[1]] for p in positions])
-            for i, (x, y) in enumerate(zip(X_grid.ravel(), Y_grid.ravel())):
-                v3d = get_velocity(np.asarray([x, y, 0]))
-                U[i] = v3d[0]
-                V[i] = v3d[1]
+    velocities = None
+    if resolution is not None:
+        x_res, y_res = resolution
+        X = np.linspace(x_min, x_max, x_res)
+        Y = np.linspace(y_min, y_max, y_res)
+        X_grid, Y_grid = np.meshgrid(X, Y)
 
-    q = ax.quiver(
-        X_grid,
-        Y_grid,
-        U.reshape(X_grid.shape),
-        V.reshape(Y_grid.shape),
-        pivot="mid",
-        alpha=0.3,
-    )
-    s = ax.scatter(P[:, 0], P[:, 1], marker=marker, c=colors, cmap=cmap)
-    return fig, ax, q, s
+        U = np.zeros_like(X_grid.ravel())
+        V = np.zeros_like(Y_grid.ravel())
+        for i, (x, y) in enumerate(zip(X_grid.ravel(), Y_grid.ravel())):
+            p = np.zeros(3)
+            p[horizontal] = x
+            p[vertical] = y
+            v3d = get_velocity(p)
+            U[i] = v3d[horizontal]
+            V[i] = v3d[vertical]
+
+        velocities = ax.quiver(
+            X_grid,
+            Y_grid,
+            U.reshape(X_grid.shape),
+            V.reshape(Y_grid.shape),
+            pivot="mid",
+            alpha=0.25,
+            scale=scale,
+        )
+
+    P = np.asarray([[p[horizontal], p[vertical]] for p in positions])
+    if cpo_vectors is not None:
+        if cpo_strengths is None:
+            cpo_strengths = np.full(len(cpo_vectors), 1.0)
+        C = np.asarray(
+            [
+                f * np.asarray([c[horizontal], c[vertical]])
+                for f, c in zip(cpo_strengths, cpo_vectors)
+            ]
+        )
+        cpo = ax.quiver(
+            P[:, 0],
+            P[:, 1],
+            C[:, 0],
+            C[:, 1],
+            colors,
+            cmap=cmap,
+            pivot="mid",
+            width=3e-3,
+            headaxislength=0,
+            headlength=0,
+            zorder=10,
+        )
+    else:
+        cpo = ax.scatter(P[:, 0], P[:, 1], marker=marker, c=colors, cmap=cmap)
+    return fig, ax, velocities, cpo
 
 
 def alignment(
@@ -244,7 +274,8 @@ def alignment(
     If `ax` is None, a new figure and axes are created with `figure_unless`.
 
     Args:
-    - `strains` (array) — X-values, accumulated strain (tensorial) during CPO evolution
+    - `strains` (array) — X-values, accumulated strain (tensorial) during CPO evolution,
+      may be a 2D array of multiple strain series
     - `angles` (array) — Y-values, may be a 2D array of multiple angle series
     - `markers` (sequence) — MatPlotLib markers to use for the data series
     - `labels` (sequence) — labels to use for the data series
@@ -262,21 +293,24 @@ def alignment(
     the data series plots.
 
     """
+    _strains = np.atleast_2d(strains)
     _angles = np.atleast_2d(angles)
-    if len(strains) != len(_angles) != len(markers) != len(labels):
+    if len(_strains) != len(_angles) != len(markers) != len(labels):
         raise ValueError("mismatch in input dimensions")
     if err is not None:
         _angles_err = np.atleast_2d(err)
         if not np.all(_angles.shape == _angles_err.shape):
-            raise ValueError("mismatch in shapes of `angles` and `angles_err`")
+            raise ValueError("mismatch in shapes of `angles` and `err`")
 
     fig, ax = figure_unless(ax)
     ax.set_ylabel("Mean angle ∈ [0, 90]°")
     ax.set_ylim((0, θ_max))
     ax.set_xlabel("Strain (ε = γ/2)")
-    ax.set_xlim((strains[0], strains[-1]))
+    ax.set_xlim((np.min(strains), np.max(strains)))
     _colors = []
-    for i, (θ_cpo, marker, label) in enumerate(zip(_angles, markers, labels)):
+    for i, (strains, θ_cpo, marker, label) in enumerate(
+        zip(_strains, _angles, markers, labels)
+    ):
         if colors is not None:
             ax.scatter(
                 strains,
@@ -285,6 +319,8 @@ def alignment(
                 label=label,
                 c=colors[i],
                 cmap=cmaps[i],
+                alpha=0.6,
+                edgecolor=plt.rcParams["axes.edgecolor"],
             )
             _colors.append(colors[i])
         else:
@@ -302,7 +338,93 @@ def alignment(
             )
 
     if θ_fse is not None:
-        ax.plot(strains, θ_fse, linestyle=(0, (5, 5)), alpha=0.66, label="FSE")
+        ax.plot(strains, θ_fse, linestyle=(0, (5, 5)), alpha=0.6, label="FSE")
+    if not all(b is None for b in labels):
+        _utils.redraw_legend(ax)
+    return fig, ax, _colors
+
+
+def strengths(
+    ax,
+    strains,
+    strengths,
+    ylabel,
+    markers,
+    labels,
+    err=None,
+    cpo_threshold=None,
+    colors=None,
+    cmaps=None,
+):
+    """Plot CPO `strengths` (e.g. M-indices) versus `strains` on the given axis.
+
+    If `ax` is None, a new figure and axes are created with `figure_unless`.
+
+    Args:
+    - `strains` (array) — X-values, accumulated strain (tensorial) during CPO evolution,
+      may be a 2D array of multiple strain series
+    - `strengths` (array) — Y-values, may be a 2D array of multiple strength series
+    - `markers` (sequence) — MatPlotLib markers to use for the data series
+    - `labels` (sequence) — labels to use for the data series
+    - `err` (array, optional) — standard errors for the `strengths`, shapes must match
+    - `colors` (array, optional) — color coordinates for series of strengths
+    - `cpo_threshold` (float, optional) — plot a dashed line at this threshold
+    - `cmaps` (Matplotlib color maps, optional) — color maps for `colors`
+
+    If `colors` and `cmaps` are used, then strength values are colored individually
+    within each strength series.
+
+    Returns a tuple of the figure handle, the axes handle and the set of colors used for
+    the data series plots.
+
+    """
+    _strains = np.atleast_2d(strains)
+    _strengths = np.atleast_2d(strengths)
+    if len(_strains) != len(_strengths) != len(markers) != len(labels):
+        raise ValueError("mismatch in input dimensions")
+    if err is not None:
+        _strengths_err = np.atleast_2d(err)
+        if not np.all(_strengths.shape == _strengths_err.shape):
+            raise ValueError("mismatch in shapes of `strengths` and `err`")
+
+    fig, ax = figure_unless(ax)
+    ax.set_ylabel(ylabel)
+    ax.set_xlabel("Strain (ε = γ/2)")
+    ax.set_xlim((np.min(strains), np.max(strains)))
+
+    if cpo_threshold is not None:
+        ax.axhline(cpo_threshold, color=plt.rcParams["axes.edgecolor"], linestyle="--")
+
+    _colors = []
+    for i, (strains, strength, marker, label) in enumerate(
+        zip(_strains, _strengths, markers, labels)
+    ):
+        if colors is not None:
+            ax.scatter(
+                strains,
+                strength,
+                marker=marker,
+                label=label,
+                c=colors[i],
+                cmap=cmaps[i],
+                alpha=0.6,
+                edgecolor=plt.rcParams["axes.edgecolor"],
+            )
+            _colors.append(colors[i])
+        else:
+            lines = ax.plot(
+                strains, strength, marker, markersize=5, alpha=0.33, label=label
+            )
+            _colors.append(lines[0].get_color())
+        if err is not None:
+            ax.fill_between(
+                strains,
+                strength - _strengths_err[i],
+                strength + _strengths_err[i],
+                alpha=0.22,
+                color=_colors[i],
+            )
+
     if not all(b is None for b in labels):
         _utils.redraw_legend(ax)
     return fig, ax, _colors
@@ -466,289 +588,13 @@ def figure_unless(ax):
     return fig, ax
 
 
-def figure():
+def figure(**kwargs):
     """Create new figure with a few opinionated default settings.
 
     (e.g. grid, constrained layout, high DPI).
 
     """
     return plt.figure()
-
-
-def _get_marker_and_label(data, seq_index, markers, labels=None):
-    marker = markers[int(seq_index / (len(data) / len(markers)))]
-    label = None
-    if labels is not None:
-        label = labels[int(seq_index / (len(data) / len(labels)))]
-    return marker, label
-
-
-def simple_shear_stationary_2d(
-    strains,
-    angles,
-    point100_symmetry,
-    target_angles=None,
-    angles_err=None,
-    savefile="pydrex_simple_shear_stationary_2d.png",
-    markers=("."),
-    θ_fse=None,
-    labels=None,
-    a_type=True,
-):
-    """Plot diagnostics for stationary A-type olivine 2D simple shear box tests."""
-    fig = plt.figure(figsize=(5, 8))
-    grid = fig.add_gridspec(2, 1, hspace=0.05)
-    ax_mean = fig.add_subplot(grid[0])
-    ax_mean.set_ylabel("Mean angle ∈ [0, 90]°")
-    ax_mean.tick_params(labelbottom=False)
-    ax_mean.set_xlim((strains[0], strains[-1]))
-    ax_mean.set_ylim((0, 60))
-    ax_symmetry = fig.add_subplot(grid[1], sharex=ax_mean)
-    ax_symmetry.set_xlim((strains[0], strains[-1]))
-    ax_symmetry.set_ylim((0, 1))
-    ax_symmetry.set_ylabel(r"Texture symmetry ($P_{[100]}$)")
-    ax_symmetry.set_xlabel("Strain (ε = γ/2)")
-
-    angles = np.atleast_2d(angles)
-    point100_symmetry = np.atleast_2d(point100_symmetry)
-    if target_angles is None:
-        target_angles = [None] * len(angles)
-    for i, (θ_target, θ, point100) in enumerate(
-        zip(target_angles, angles, point100_symmetry)
-    ):
-        marker, label = _get_marker_and_label(angles, i, markers, labels)
-
-        lines = ax_mean.plot(strains, θ, marker, markersize=5, alpha=0.33)
-        color = lines[0].get_color()
-        if θ_target is not None:
-            lines = ax_mean.plot(
-                strains, θ_target, alpha=0.66, label=label, color=color
-            )
-        if angles_err is not None:
-            ax_mean.fill_between(
-                strains, θ - angles_err[i], θ + angles_err[i], alpha=0.22, color=color
-            )
-        ax_symmetry.plot(
-            strains,
-            point100,
-            marker,
-            markersize=5,
-            alpha=0.33,
-            color=color,
-            label=label,
-        )
-
-    if a_type:
-        data_Skemer2016 = _io.read_scsv(
-            _io.data("thirdparty") / "Skemer2016_ShearStrainAngles.scsv"
-        )
-        indices_ZK1200 = np.nonzero(np.asarray(data_Skemer2016.study) == "Z&K 1200 C")[
-            0  # Note: np.nonzero returns a tuple.
-        ]
-        ax_mean.plot(
-            np.take(data_Skemer2016.shear_strain, indices_ZK1200) / 200,
-            np.take(data_Skemer2016.angle, indices_ZK1200),
-            marker="v",
-            fillstyle="none",
-            linestyle="none",
-            markersize=5,
-            color="k",
-            label="Zhang & Karato, 1995\n(1200°C)",
-        )
-        indices_ZK1300 = np.nonzero(np.asarray(data_Skemer2016.study) == "Z&K 1300 C")[
-            0  # Note: np.nonzero returns a tuple.
-        ]
-        ax_mean.plot(
-            np.take(data_Skemer2016.shear_strain, indices_ZK1300) / 200,
-            np.take(data_Skemer2016.angle, indices_ZK1300),
-            marker="^",
-            linestyle="none",
-            markersize=5,
-            color="k",
-            label="Zhang & Karato, 1995\n(1300°C)",
-        )
-    if θ_fse is not None:
-        ax_mean.plot(strains, θ_fse, linestyle=(0, (5, 5)), alpha=0.66, label="FSE")
-    if labels is not None:
-        ax_mean.legend()
-        ax_symmetry.legend()
-
-    fig.savefig(_io.resolve_path(savefile))
-
-
-def corner_flow_2d(
-    x_paths,
-    z_paths,
-    angles,
-    indices,
-    directions,
-    timestamps,
-    xlabel,
-    savefile="pydrex_corner_2d.png",
-    markers=("."),
-    labels=None,
-    xlims=None,
-    zlims=None,
-    cpo_threshold=0.33,
-    Π_levels=(0.1, 0.5, 1, 2, 3),
-    tick_formatter=lambda x, pos: f"{x/1e3:.1f} km",
-):
-    """Plot diagnostics for prescribed path 2D corner flow tests.
-
-    .. warning:: This method is in need of repair.
-
-    """
-    fig = plt.figure(figsize=(12, 8))
-    grid = fig.add_gridspec(2, 2, hspace=-0.2, wspace=0.025)
-    ax_domain = fig.add_subplot(grid[0, :])
-    ax_domain.set_ylabel("z")
-    ax_domain.set_xlabel(xlabel)
-    ax_domain.xaxis.set_ticks_position("top")
-    ax_domain.xaxis.set_label_position("top")
-    ax_domain.set_aspect("equal")
-    ax_domain.xaxis.set_major_formatter(tick_formatter)
-    ax_domain.yaxis.set_major_formatter(tick_formatter)
-    ax_strength = fig.add_subplot(grid[1, 0])
-    ax_strength.set_ylabel("Texture strength (M-index)")
-    ax_strength.set_xlabel("Time (s)")
-    ax_mean = fig.add_subplot(grid[1, 1])
-    ax_mean.set_ylabel("Mean angle from horizontal (°)")
-    ax_mean.set_xlabel("Time (s)")
-    ax_mean.set_ylim((0, 90))
-    ax_mean.yaxis.set_ticks_position("right")
-    ax_mean.yaxis.set_label_position("right")
-
-    for i, (
-        misorient_angles,
-        misorient_indices,
-        x_series,
-        z_series,
-        bingham_vectors,
-        t_series,
-    ) in enumerate(zip(angles, indices, x_paths, z_paths, directions, timestamps)):
-        x_series = np.array(x_series)
-        z_series = np.array(z_series)
-        # Π := grain orientation lag, dimensionless, see Kaminski 2002.
-        Π_series = _utils.lag_2d_corner_flow(np.arctan2(x_series, -z_series))
-        Π_max_step = np.argmax(Π_series)
-        # Index of timestamp where Π ≈ 1 (corner).
-        corner_step = Π_max_step + np.argmin(np.abs(Π_series[Π_max_step:] - 1.0))
-
-        marker, label = _get_marker_and_label(angles, i, markers, labels)
-
-        mean_angles = ax_mean.plot(
-            t_series,
-            misorient_angles,
-            marker,
-            markersize=5,
-            alpha=0.33,
-            label=label,
-        )
-        color = mean_angles[0].get_color()  # `mean_angles` has one element.
-        ax_mean.plot(
-            t_series[corner_step],
-            misorient_angles[corner_step],
-            marker,
-            markersize=5,
-            color=plt.rcParams["axes.edgecolor"],
-            zorder=11,
-            alpha=0.33,
-        )
-        ax_strength.plot(
-            t_series[corner_step],
-            misorient_indices[corner_step],
-            marker,
-            markersize=5,
-            color=plt.rcParams["axes.edgecolor"],
-            zorder=11,
-            alpha=0.33,
-        )
-        ax_strength.plot(
-            t_series,
-            misorient_indices,
-            marker,
-            markersize=5,
-            color=color,
-            alpha=0.33,
-            label=label,
-        )
-
-        # Plot the prescribed pathlines, indicate CPO and location of Π ≈ 1.
-        mask_cpo = misorient_indices > cpo_threshold
-        ax_domain.plot(
-            x_series[~mask_cpo],
-            z_series[~mask_cpo],
-            marker,
-            markersize=5,
-            alpha=0.33,
-            label=label,
-            zorder=10,
-        )
-        if np.any(mask_cpo):
-            # TODO: Scale bingham_vectors by a meaningful length; FSE long axis?
-            ax_domain.quiver(
-                x_series[mask_cpo],
-                z_series[mask_cpo],
-                bingham_vectors[mask_cpo, 0],
-                bingham_vectors[mask_cpo, 2],
-                color=color,
-                pivot="mid",
-                width=3e-3,
-                headaxislength=0,
-                headlength=0,
-                zorder=10,
-            )
-        ax_domain.plot(
-            x_series[corner_step],
-            z_series[corner_step],
-            marker,
-            markersize=5,
-            color=plt.rcParams["axes.edgecolor"],
-            zorder=11,
-        )
-        if xlims is not None:
-            ax_domain.set_xlim(*xlims)
-        if zlims is not None:
-            ax_domain.set_ylim(*zlims)
-
-    # Plot grain orientation lag contours.
-    x_ticks = np.linspace(
-        *ax_domain.get_xlim(), len(ax_domain.xaxis.get_major_ticks()) * 10 + 1
-    )
-    z_ticks = np.linspace(
-        *ax_domain.get_ylim(), len(ax_domain.yaxis.get_major_ticks()) * 10 + 1
-    )
-    x_grid, z_grid = np.meshgrid(x_ticks, z_ticks)
-    θ_grid = np.arctan2(x_grid, -z_grid)
-    Π_contours = ax_domain.contourf(
-        x_ticks,
-        z_ticks,
-        _utils.lag_2d_corner_flow(θ_grid),
-        levels=Π_levels,
-        extend="min",
-        cmap="copper_r",
-        alpha=0.33,
-    )
-    # Some hacky workaround to have better edges between the contours.
-    for c in Π_contours.collections:
-        c.set_edgecolor("face")
-    plt.rcParams["axes.grid"] = False
-    divider = make_axes_locatable(ax_domain)
-    fig.colorbar(
-        Π_contours,
-        label="grain orientation lag, Π",
-        cax=divider.append_axes("right", size="2%", pad=0.05),
-    ).ax.invert_xaxis()
-    plt.rcParams["axes.grid"] = True
-
-    # Lines to show texture threshold and shear direction.
-    ax_strength.axhline(
-        cpo_threshold, color=plt.rcParams["axes.edgecolor"], linestyle="--"
-    )
-    if labels is not None:
-        ax_mean.legend()
-
-    fig.savefig(_io.resolve_path(savefile))
 
 
 def single_olivineA_simple_shear(

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -2,7 +2,6 @@
 import numpy as np
 from matplotlib import projections as mproj
 from matplotlib import pyplot as plt
-from mpl_toolkits.axes_grid1 import make_axes_locatable
 from cmcrameri import cm as cmc
 
 from pydrex import axes as _axes

--- a/tests/test_corner_flow_2d.py
+++ b/tests/test_corner_flow_2d.py
@@ -1,54 +1,12 @@
-r"""> PyDRex: 2D corner flow tests
-
-The flow field is defined by:
-$$
-\bm{u} = \frac{dr}{dt} \bm{\hat{r}} + r \frac{dθ}{dt} \bm{\hat{θ}}
-= \frac{2 U}{π}(θ\sinθ - \cosθ) ⋅ \bm{\hat{r}} + \frac{2 U}{π}θ\cosθ ⋅ \bm{\hat{θ}}
-$$
-where $θ = 0$ points vertically downwards along the ridge axis
-and $θ = π/2$ points along the surface. $U$ is the half spreading velocity.
-Streamlines for the flow obey:
-$$
-ψ = \frac{2 U r}{π}θ\cosθ
-$$
-and are related to the velocity through:
-$$
-\bm{u} = -\frac{1}{r} ⋅ \frac{dψ}{dθ} ⋅ \bm{\hat{r}} + \frac{dψ}{dr}\bm{\hat{θ}}
-$$
-Conversion to Cartesian ($x,y,z$) coordinates yields:
-$$
-\bm{u} = \frac{2U}{π} \left[
-\tan^{-1}\left(\frac{x}{-z}\right) + \frac{xz}{x^{2} + z^{2}} \right] \bm{\hat{x}} +
-\frac{2U}{π} \frac{z^{2}}{x^{2} + z^{2}} \bm{\hat{z}}
-$$
-where
-\begin{align\*}
-x &= r \sinθ \cr
-z &= -r \cosθ
-\end{align\*}
-and the velocity gradient is:
-$$
-L = \frac{4 U}{π{(x^{2}+z^{2})}^{2}} ⋅
-\begin{bmatrix}
-    -x^{2}z & 0 & x^{3} \cr
-    0 & 0 & 0 \cr
-    -xz^{2} & 0 & x^{2}z
-\end{bmatrix}
-$$
-
-See also Fig. 5 in [Kaminski & Ribe, 2002](https://doi.org/10.1029/2001GC000222).
-
-"""
+"""> PyDRex: 2D corner flow tests."""
 import contextlib as cl
-import itertools as it
 import pathlib as pl
-import time
+import functools as ft
+from multiprocessing import Pool
+from time import perf_counter
 
-import numba as nb
 import numpy as np
 import pytest
-from numpy import testing as nt
-from scipy.spatial.transform import Rotation
 
 from pydrex import core as _core
 from pydrex import diagnostics as _diagnostics
@@ -56,62 +14,99 @@ from pydrex import geometry as _geo
 from pydrex import io as _io
 from pydrex import logger as _log
 from pydrex import minerals as _minerals
-from pydrex import pathlines as _pathlines
+from pydrex import pathlines as _path
 from pydrex import stats as _stats
 from pydrex import visualisation as _vis
+from pydrex import velocity as _velocity
+from pydrex import utils as _utils
+
+# Subdirectory of `outdir` used to store outputs from these tests.
+SUBDIR = "2d_cornerflow"
 
 
-@nb.njit
-def get_velocity(x, z, plate_velocity):
-    """Return velocity in a corner flow (Cartesian coordinate basis)."""
-    return (2 * plate_velocity / np.pi) * np.array(
-        [np.arctan2(x, -z) + x * z / (x**2 + z**2), 0.0, z**2 / (x**2 + z**2)]
-    )
-
-
-@nb.njit
-def get_velocity_gradient(x, z, plate_velocity):
-    """Return velocity gradient in a corner flow (Cartesian coordinate basis)."""
-    return (4.0 * plate_velocity / (np.pi * (x**2 + z**2) ** 2)) * np.array(
-        [[-(x**2) * z, 0.0, x**3], [0.0, 0.0, 0.0], [-x * z**2, 0.0, x**2 * z]]
-    )
-
-
-class TestOlivineA:
+class TestCornerOlivineA:
     """Tests for pure A-type olivine polycrystals in 2D corner flows."""
 
-    @pytest.mark.slow
-    def test_corner_prescribed_init_isotropic(
-        self,
-        params_Kaminski2001_fig5_shortdash,
+    class_id = "corner_olivineA"
+
+    @classmethod
+    def run(
+        cls,
+        params,
         seed,
-        outdir,
+        get_velocity,
+        get_velocity_gradient,
+        min_coords,
+        max_coords,
+        max_strain,
+        n_timesteps,
+        final_location,
     ):
+        """Run 2D corner flow A-type olivine simulation."""
+        mineral = _minerals.Mineral(
+            _core.MineralPhase.olivine,
+            _core.MineralFabric.olivine_A,
+            _core.DeformationRegime.dislocation,
+            n_grains=params["number_of_grains"],
+        )
+        deformation_gradient = np.eye(3)
+        timestamps_back, get_position = _path.get_pathline(
+            final_location,
+            get_velocity,
+            get_velocity_gradient,
+            min_coords,
+            max_coords,
+            max_strain,
+        )
+        timestamps = np.linspace(timestamps_back[-1], timestamps_back[0], n_timesteps)
+        positions = [get_position(t) for t in timestamps]
+        velocity_gradients = [get_velocity_gradient(np.asarray(x)) for x in positions]
+        strains = np.empty_like(timestamps)
+        strains[0] = 0
+        for t, time in enumerate(timestamps[:-1], start=1):
+            strains[t] = strains[t - 1] + (
+                _utils.strain_increment(timestamps[t] - time, velocity_gradients[t])
+            )
+            _log.info("step %d/%d (ε = %.2f)", t, len(timestamps) - 1, strains[t])
+
+            deformation_gradient = mineral.update_orientations(
+                params,
+                deformation_gradient,
+                get_velocity_gradient,
+                pathline=(time, timestamps[t], get_position),
+            )
+        return timestamps, positions, strains, mineral, deformation_gradient
+
+    @pytest.mark.slow
+    def test_prescribed(self, outdir, params_Kaminski2001_fig5_shortdash, seed, ncpus):
         """Test CPO evolution in prescribed 2D corner flow.
 
         Initial condition: random orientations and uniform volumes in all `Mineral`s.
 
         Plate velocity: 2 cm/yr
 
+        .. note::
+            This example takes about 11 CPU hours to run and uses around 60GB of RAM.
+
         """
-        # Plate velocity (half spreading rate), convert cm/yr to m/s.
-        plate_velocity = 2.0 / (100.0 * 365.0 * 86400.0)
+        # Plate speed (half spreading rate), convert cm/yr to m/s.
+        plate_speed = 2.0 / (100.0 * 365.0 * 86400.0)
         domain_height = 2.0e5  # Represents the depth of olivine-spinel transition.
         domain_width = 1.0e6
-        n_grains = 2000
-        orientations_init = Rotation.random(n_grains, random_state=seed).as_matrix()
-        n_timesteps = 20  # Number of places along the pathline to compute CPO.
+        params = params_Kaminski2001_fig5_shortdash
+        n_timesteps = 50  # Number of places along the pathline to compute CPO.
+        get_velocity, get_velocity_gradient = _velocity.corner_2d("X", "Z", plate_speed)
         # Z-values at the end of each pathline.
         z_ends = list(map(lambda x: x * domain_height, (-0.1, -0.3, -0.54, -0.78)))
-        test_id = "corner_olivineA_prescribed"  # Unique string ID of this test.
 
         # Optional plotting and logging setup.
         optional_logging = cl.nullcontext()
         if outdir is not None:
-            optional_logging = _log.logfile_enable(f"{outdir}/{test_id}.log")
-            npzpath = pl.Path(f"{outdir}/{test_id}.npz")
+            out_basepath = f"{outdir}/{SUBDIR}/{self.class_id}_prescribed"
+            optional_logging = _log.logfile_enable(f"{out_basepath}.log")
+            npzpath = pl.Path(f"{out_basepath}.npz")
             # Clean up existing output file to prevent appending to it.
-            npzpath.unlink(missing_ok=True)  # missing_ok: Python 3.8
+            # npzpath.unlink(missing_ok=True)  # missing_ok: Python 3.8
             labels = []
             angles = []
             indices = []
@@ -120,231 +115,66 @@ class TestOlivineA:
             directions = []
             timestamps = []
 
-        # Callables used to prescribe the macroscopic fields.
-        @nb.njit
-        def _get_velocity(point):
-            x, _, z = np.asarray(point)
-            return get_velocity(x, z, plate_velocity)
+        _run = ft.partial(
+            self.run,
+            params,
+            seed,
+            get_velocity,
+            get_velocity_gradient,
+            np.array([0.0, 0.0, -domain_height]),
+            np.array([domain_width, 0.0, 0.0]),
+            10,
+            n_timesteps,
+        )
 
-        @nb.njit
-        def _get_velocity_gradient(point):
-            x, _, z = np.asarray(point)
-            # Return with an extra dimension of shape 1, like scipy RBF.
-            return get_velocity_gradient(x, z, plate_velocity)
-
+        final_locations = [np.array([domain_width, 0.0, z_exit]) for z_exit in z_ends]
         with optional_logging:
-            _begin = time.perf_counter()
-            for z_exit in z_ends:
-                mineral = _minerals.Mineral(
-                    _core.MineralPhase.olivine,
-                    _core.MineralFabric.olivine_A,
-                    _core.DeformationRegime.dislocation,
-                    n_grains=n_grains,
-                    fractions_init=np.full(n_grains, 1 / n_grains),
-                    orientations_init=orientations_init,
-                )
-                timestamps_back, get_position = _pathlines.get_pathline(
-                    np.array([domain_width, 0.0, z_exit]),
-                    _get_velocity,
-                    _get_velocity_gradient,
-                    min_coords=np.array([0.0, 0.0, -domain_height]),
-                    max_coords=np.array([domain_width, 0.0, 0.0]),
-                )
-                x_vals = []
-                z_vals = []
-                deformation_gradient = np.eye(3)
-                times = np.linspace(
-                    timestamps_back[-1], timestamps_back[0], n_timesteps
-                )
-                for time_start, time_end in it.pairwise(times):
-                    deformation_gradient = mineral.update_orientations(
-                        params_Kaminski2001_fig5_shortdash,
-                        deformation_gradient,
-                        _get_velocity_gradient,
-                        pathline=(time_start, time_end, get_position),
+            _begin = perf_counter()
+            with Pool(processes=ncpus) as pool:
+                for i, out in enumerate(pool.map(_run, final_locations)):
+                    times, positions, strains, mineral, deformation_gradient = out
+                    _log.info("final deformation gradient:\n%s", deformation_gradient)
+                    z_exit = z_ends[i]
+                    if outdir is not None:
+                        mineral.save(npzpath, _io.stringify(z_exit))
+
+                    misorient_angles = np.zeros(n_timesteps)
+                    bingham_vectors = np.zeros((n_timesteps, 3))
+                    orientations_resampled, _ = _stats.resample_orientations(
+                        mineral.orientations, mineral.fractions, seed=seed
                     )
-                    x_current, _, z_current = get_position(time_start)
-                    x_vals.append(x_current)
-                    z_vals.append(z_current)
-
-                x_vals.append(domain_width)
-                z_vals.append(z_exit)
-
-                _log.info("final deformation gradient:\n%s", deformation_gradient)
-                if outdir is not None:
-                    mineral.save(f"{outdir}/{test_id}.npz", _io.stringify(z_exit))
-
-                assert (
-                    n_timesteps
-                    == len(mineral.orientations)
-                    == len(mineral.fractions)
-                    == len(x_vals)
-                    == len(z_vals)
-                ), (
-                    f"n_timesteps = {n_timesteps}\n"
-                    + f"len(mineral.orientations) = {len(mineral.orientations)}\n"
-                    + f"len(mineral.fractions) = {len(mineral.fractions)}\n"
-                    + f"len(x_vals) = {len(x_vals)}\n"
-                    + f"len(z_vals) = {len(z_vals)}\n"
-                )
-
-                misorient_angles = np.zeros(n_timesteps)
-                misorient_indices = np.zeros(n_timesteps)
-                bingham_vectors = np.zeros((n_timesteps, 3))
-                # Loop over first dimension (time steps) of resampled orientations.
-                orientations_resampled, _ = _stats.resample_orientations(
-                    mineral.orientations, mineral.fractions, seed=seed
-                )
-                for idx, matrices in enumerate(orientations_resampled):
-                    direction_mean = _diagnostics.bingham_average(
-                        matrices,
-                        axis=_minerals.OLIVINE_PRIMARY_AXIS[mineral.fabric],
+                    misorient_indices = _diagnostics.misorientation_indices(
+                        orientations_resampled,
+                        _geo.LatticeSystem.orthorhombic,
+                        ncpus=ncpus,
                     )
-                    misorient_angles[idx] = _diagnostics.smallest_angle(
-                        direction_mean,
-                        [1, 0, 0],
+                    for idx, matrices in enumerate(orientations_resampled):
+                        direction_mean = _diagnostics.bingham_average(
+                            matrices,
+                            axis=_minerals.OLIVINE_PRIMARY_AXIS[mineral.fabric],
+                        )
+                        misorient_angles[idx] = _diagnostics.smallest_angle(
+                            direction_mean,
+                            [1, 0, 0],
+                        )
+                        bingham_vectors[idx] = direction_mean
+
+                    _log.debug(
+                        "Total walltime: %s",
+                        _utils.readable_timestamp(perf_counter() - _begin),
                     )
-                    misorient_indices[idx] = _diagnostics.misorientation_index(
-                        matrices, _geo.LatticeSystem.orthorhombic
-                    )
-                    bingham_vectors[idx] = direction_mean
 
-                _log.debug(
-                    "Total walltime: %s minutes", (time.perf_counter() - _begin) / 60
-                )
-
-                if outdir is not None:
-                    mineral.save(npzpath, postfix=_io.stringify(z_exit))
-                    labels.append(rf"$z_{{f}}$ = {z_exit/1e3:.1f} km")
-                    angles.append(misorient_angles)
-                    indices.append(misorient_indices)
-                    x_paths.append(x_vals)
-                    z_paths.append(z_vals)
-                    timestamps.append(times)
-                    directions.append(bingham_vectors)
-
-                # fmt: off
-                match z_exit:
-                    case -0.1:
-                        nt.assert_allclose(
-                            misorient_indices,
-                            np.array(
-                                [
-                                    0.29354073, 0.29139814, 0.28965082, 0.26923181,
-                                    0.43728815, 0.55902656, 0.67040709, 0.71021054,
-                                    0.66081722, 0.65040127, 0.66930637, 0.67661135,
-                                    0.63910248, 0.6707902, 0.66679258, 0.67516914,
-                                    0.69877907, 0.72979705, 0.73528611, 0.71979801,
-                                ]
-                            ),
-                            atol=1e-6,
-                            rtol=1e-99,
-                        )
-                        nt.assert_allclose(
-                            misorient_angles,
-                            np.array(
-                                [
-                                    22.24261747, 24.99605342, 29.71796518, 40.0912132,
-                                    58.41158265, 36.86306583, 31.87868878, 30.11087659,
-                                    26.51558709, 23.34835358, 23.41384721, 21.93323976,
-                                    21.48935828, 20.08908965, 19.57542213, 18.6647496,
-                                    17.5105292, 15.91363738, 14.33753086, 13.41946783,
-                                ]
-                            ),
-                            atol=1e-6,
-                            rtol=1e-99,
-                        )
-                    case -0.3:
-                        nt.assert_allclose(
-                            misorient_indices,
-                            np.array(
-                                [
-                                    0.2940009, 0.28771646, 0.27639005, 0.25886719,
-                                    0.40972653, 0.50731756, 0.60316864, 0.64811264,
-                                    0.69256278, 0.71008648, 0.73889148, 0.74481225,
-                                    0.75434712, 0.75209596, 0.75393394, 0.7675225,
-                                    0.76246927, 0.77881215, 0.77141318, 0.77484375,
-                                ]
-                            ),
-                            atol=1e-6,
-                            rtol=1e-99,
-                        )
-                        nt.assert_allclose(
-                            misorient_angles,
-                            np.array(
-                                [
-                                    5.91728301, 17.07815867, 23.25332998, 34.17169797,
-                                    41.66395009, 36.79018269, 32.55988675, 30.14552646,
-                                    27.30582272, 25.49009754, 24.4217203, 22.90840585,
-                                    21.66657909, 20.68103436, 20.27783999, 20.06226786,
-                                    20.20396384, 19.95005673, 20.09769095, 20.10364311,
-                                ]
-                            ),
-                            atol=1e-6,
-                            rtol=1e-99,
-                        )
-                    case -0.54:
-                        nt.assert_allclose(
-                            misorient_indices,
-                            np.array(
-                                [
-                                    0.2944119, 0.28656134, 0.27582298, 0.25884225,
-                                    0.2615378, 0.32354765, 0.44345791, 0.51995699,
-                                    0.59311994, 0.63452573, 0.6788792, 0.6994935,
-                                    0.71107442, 0.73233345, 0.75584854, 0.76953765,
-                                    0.77943593, 0.78909139, 0.80136383, 0.7946032,
-                                ]
-                            ),
-                            atol=1e-6,
-                            rtol=1e-99,
-                        )
-                        nt.assert_allclose(
-                            misorient_angles,
-                            np.array(
-                                [
-                                    40.7125026, 5.52574182, 2.06510475, 9.51367731,
-                                    16.48842428, 22.11392716, 24.85899564, 24.54769036,
-                                    24.14955996, 23.90791376, 23.3676604, 23.07129318,
-                                    22.65626005, 22.61909731, 22.63638591, 23.00285289,
-                                    22.74623449, 22.79083959, 22.05867133, 22.29152601,
-                                ]
-                            ),
-                            atol=1e-6,
-                            rtol=1e-99,
-                        )
-                    case -0.78:
-                        nt.assert_allclose(
-                            misorient_indices,
-                            np.array(
-                                [
-                                    0.29382031, 0.29141999, 0.29000587, 0.28289251,
-                                    0.27760402, 0.27496249, 0.26485081, 0.26716991,
-                                    0.26558728, 0.27393002, 0.29054229, 0.3169605,
-                                    0.34624343, 0.38476239, 0.4217034, 0.46967351,
-                                    0.48761024, 0.51957981, 0.53310085, 0.57009067,
-                                ]
-                            ),
-                            atol=1e-6,
-                            rtol=1e-99,
-                        )
-                        nt.assert_allclose(
-                            misorient_angles,
-                            np.array(
-                                [
-                                    74.10661435, 23.96729185, 20.59992663, 17.02088753,
-                                    9.09000678, 6.04395152, 4.58153096, 2.96577108,
-                                    2.9621749, 2.68839051, 7.07400922, 8.1715697,
-                                    9.02297977, 11.96472443, 11.46670069, 12.97670256,
-                                    13.70356205, 13.50136437, 14.73625771, 14.49643156,
-                                ]
-                            ),
-                            atol=1e-6,
-                            rtol=1e-99,
-                        )
-                # fmt: on
+                    if outdir is not None:
+                        mineral.save(npzpath, postfix=_io.stringify(z_exit))
+                        labels.append(rf"$z_{{f}}$ = {z_exit/1e3:.1f} km")
+                        angles.append(misorient_angles)
+                        indices.append(misorient_indices)
+                        x_paths.append([p[0] for p in positions])
+                        z_paths.append([p[2] for p in positions])
+                        timestamps.append(times)
+                        directions.append(bingham_vectors)
 
         if outdir is not None:
-            # np.savez(f"{outdir}/{test_id}_diagnostics.npz", *angles, *indices)
             _vis.corner_flow_2d(
                 x_paths,
                 z_paths,
@@ -352,34 +182,10 @@ class TestOlivineA:
                 indices,
                 directions,
                 timestamps,
-                xlabel=f"x ⇀ ({plate_velocity:.2e} m/s)",
-                savefile=f"{outdir}/{test_id}.png",
+                xlabel=f"x ⇀ ({plate_speed:.2e} m/s)",
+                savefile=f"{out_basepath}.png",
                 markers=("o", "v", "s", "p"),
                 labels=labels,
                 xlims=(0, domain_width + 0.25 * domain_height),
                 zlims=(-domain_height, 0),
             )
-
-            scsv_schema = {
-                "delimiter": ",",
-                "missing": "-",
-                "fields": [
-                    {
-                        "name": f"t_{_io.stringify(e)}",
-                        "type": "float",
-                        "fill": "NaN",
-                        "unit": "seconds",
-                    }
-                    for e in z_ends
-                ]
-                + [
-                    {"name": f"x_{_io.stringify(e)}", "type": "float", "fill": "NaN"}
-                    for e in z_ends
-                ]
-                + [
-                    {"name": f"z_{_io.stringify(e)}", "type": "float", "fill": "NaN"}
-                    for e in z_ends
-                ],
-            }
-            scsv_data = list(it.chain.from_iterable(zip(timestamps, x_paths, z_paths)))
-            _io.save_scsv(f"{outdir}/{test_id}.scsv", scsv_schema, scsv_data)

--- a/tests/test_corner_flow_2d.py
+++ b/tests/test_corner_flow_2d.py
@@ -78,7 +78,7 @@ class TestCornerOlivineA:
         return timestamps, positions, strains, mineral, deformation_gradient
 
     @pytest.mark.slow
-    def test_prescribed(self, outdir, params_Kaminski2001_fig5_shortdash, seed, ncpus):
+    def test_prescribed(self, outdir, seed, ncpus):
         """Test CPO evolution in prescribed 2D corner flow.
 
         Initial condition: random orientations and uniform volumes in all `Mineral`s.
@@ -93,7 +93,7 @@ class TestCornerOlivineA:
         plate_speed = 2.0 / (100.0 * 365.0 * 86400.0)
         domain_height = 2.0e5  # Represents the depth of olivine-spinel transition.
         domain_width = 1.0e6
-        params = params_Kaminski2001_fig5_shortdash
+        params = _io.DEFAULT_PARAMS
         params["number_of_grains"] = 5000
         n_timesteps = 50  # Number of places along the pathline to compute CPO.
         get_velocity, get_velocity_gradient = _velocity.corner_2d("X", "Z", plate_speed)

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -51,6 +51,7 @@ class TestOlivineA:
         mineral = _minerals.Mineral(
             phase=_core.MineralPhase.olivine,
             fabric=_core.MineralFabric.olivine_A,
+            regime=_core.DeformationRegime.dislocation,
             n_grains=params["number_of_grains"],
             seed=seed,
         )

--- a/tests/test_vortex_2d.py
+++ b/tests/test_vortex_2d.py
@@ -39,6 +39,7 @@ class TestCellOlivineA:
         mineral = _minerals.Mineral(
             phase=_core.MineralPhase.olivine,
             fabric=_core.MineralFabric.olivine_A,
+            regime=_core.DeformationRegime.dislocation,
             n_grains=params["number_of_grains"],
             seed=seed,
         )


### PR DESCRIPTION
Also fixes a bug with `misorientation_indices` which caused mixed up M-index outputs and apparent non-reproducible behaviour.

I have removed the old assert statements on this test for now as they don't really test much, also this test is too long for CI anyway and not very tractable as an ensemble test either, so it is mainly qualitative, but at least shows if the M-index is working.