### PR TITLE
fix: Fix velocity arrows and tick labels in 2D cell plot

### DIFF
--- a/tests/test_vortex_2d.py
+++ b/tests/test_vortex_2d.py
@@ -117,8 +117,8 @@ class TestCellOlivineA:
                 [-1, -1],
                 [1, 1],
                 [20, 20],
-                scale=1,
                 cmap="cmc.batlow_r",
+                tick_formatter=lambda x, pos: str(x),
             )
             fig_path.colorbar(s, ax=ax_path, aspect=25, label="strain (ε)")
             fig_path.savefig(_io.resolve_path(f"{out_basepath}_path.png"))


### PR DESCRIPTION
Fixes the 2D cell plots to look like before #152 