### PR TITLE
feat: Make redraw_legend more flexible; finalise GBM test figure legend

### DIFF
--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -289,7 +289,7 @@ def _get_orientation_change(
     Args:
     - `orientation` (array) — 3x3 orientation matrix (direction cosines)
     - `velocity_gradient` (array) — 3x3 dimensionless velocity gradient matrix
-    - `deformation_rate` (float) — 3x3 dimensionless strain rate matrix
+    - `deformation_rate` (float) — 3x3 dimensionless deformation rate matrix
     - `slip_rate_softest` (float) — slip rate on the softest (most active) slip system
 
     """

--- a/src/pydrex/utils.py
+++ b/src/pydrex/utils.py
@@ -59,7 +59,7 @@ def default_ncpus():
                 return int(out.stdout.strip()) - 1
             case "Windows":
                 return int(os.environ["NUMBER_OF_PROCESSORS"]) - 1
-    except AttributeError or CalledProcessError or KeyError:
+    except AttributeError or subprocess.CalledProcessError or KeyError:
         return 1
 
 

--- a/src/pydrex/utils.py
+++ b/src/pydrex/utils.py
@@ -130,7 +130,7 @@ def redraw_legend(ax, fig=None, remove_all=True, **kwargs):
         arguments `bbox_extra_artists=(legend,)` and `bbox_inches="tight"` to `savefig`,
         where `legend` is the object returned by this function. To prevent the legend
         from consuming axes/subplot space, it is further required to add the lines:
-        `legend.set_in_leyout(False)`, `fig.canvas.draw()`, `legend.set_layout(True)`
+        `legend.set_in_layout(False)`, `fig.canvas.draw()`, `legend.set_layout(True)`
         and `fig.set_layout_engine("none")` before saving the figure.
 
     """

--- a/src/pydrex/utils.py
+++ b/src/pydrex/utils.py
@@ -4,6 +4,9 @@ import subprocess
 import os
 import platform
 
+from matplotlib.pyplot import Line2D
+from matplotlib.collections import PathCollection
+from matplotlib.legend_handler import HandlerPathCollection, HandlerLine2D
 import numba as nb
 import numpy as np
 
@@ -112,12 +115,53 @@ def quat_product(q1, q2):
     ]
 
 
-def redraw_legend(ax):
-    """Redraw legend on matplotlib axis with new labels since last `ax.legend()`."""
-    legend = ax.get_legend()
-    if legend is not None:
-        legend.remove()
-    ax.legend()
+def redraw_legend(ax, fig=None, remove_all=True, **kwargs):
+    """Redraw legend on matplotlib axis or figure.
+
+    Transparency is removed from legend symbols.
+    If `fig` is not None and `remove_all` is True,
+    all legends are first removed from the parent figure.
+    Optional keyword arguments are passed to `matplotlib.axes.Axes.legend` by default,
+    or `matplotlib.figure.Figure.legend` if `fig` is not None.
+
+    .. warning::
+        Note that if `fig` is not `None`, the legend may be cropped from the saved
+        figure due to a Matplotlib bug. In this case, it is required to add the
+        arguments `bbox_extra_artists=(legend,)` and `bbox_inches="tight"` to `savefig`,
+        where `legend` is the object returned by this function. To prevent the legend
+        from consuming axes/subplot space, it is further required to add the lines:
+        `legend.set_in_leyout(False)`, `fig.canvas.draw()`, `legend.set_layout(True)`
+        and `fig.set_layout_engine("none")` before saving the figure.
+
+    """
+    handler_map={
+        PathCollection: HandlerPathCollection(
+            update_func=_remove_legend_symbol_transparency
+        ),
+        Line2D: HandlerLine2D(update_func=_remove_legend_symbol_transparency)
+    }
+    if fig is None:
+        legend = ax.get_legend()
+        if legend is not None:
+            legend.remove()
+        return ax.legend(handler_map=handler_map, **kwargs)
+    else:
+        for legend in fig.legends:
+            if legend is not None:
+                legend.remove()
+        if remove_all:
+            for ax in fig.axes:
+                legend = ax.get_legend()
+                if legend is not None:
+                    legend.remove()
+        return fig.legend(handler_map=handler_map, **kwargs)
+
+
+def _remove_legend_symbol_transparency(handle, orig):
+    """Remove transparency from symbols used in a Matplotlib legend."""
+    # https://stackoverflow.com/a/59629242/12519962
+    handle.update_from(orig)
+    handle.set_alpha(1)
 
 
 def __run_doctests():

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -1,10 +1,7 @@
 """> PyDRex: Visualisation functions for test outputs and examples."""
 import numpy as np
-import matplotlib as mpl
 from matplotlib import projections as mproj
 from matplotlib import pyplot as plt
-from matplotlib.collections import PathCollection
-from matplotlib.legend_handler import HandlerPathCollection, HandlerLine2D
 from cmcrameri import cm as cmc
 
 from pydrex import axes as _axes

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -3,6 +3,8 @@ import numpy as np
 import matplotlib as mpl
 from matplotlib import projections as mproj
 from matplotlib import pyplot as plt
+from matplotlib.collections import PathCollection
+from matplotlib.legend_handler import HandlerPathCollection, HandlerLine2D
 from cmcrameri import cm as cmc
 
 from pydrex import axes as _axes

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -481,7 +481,6 @@ class TestOlivineA:
                     ],
                 )
                 # There is a lot of stuff on this legend, so put it outside the axes.
-                # The 'loc' argument doesn't seem to work, use `bbox_to_anchor` instead.
                 # These values might need to be tweaked depending on the font size, etc.
                 _legend = _utils.redraw_legend(ax, fig=fig, bbox_to_anchor=(1.66, 0.99))
                 fig.savefig(

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -451,6 +451,11 @@ class TestOlivineA:
                     schema,
                     [[int(D * 200) for D in strains]],  # Shear strain % is 200 * D₀.
                 )
+                np.savez(
+                    f"{out_basepath}_angles.npz",
+                    angles=result_angles,
+                    err=result_angles_err
+                )
                 fig, ax, colors = _vis.alignment(
                     None,
                     strains,
@@ -475,7 +480,15 @@ class TestOlivineA:
                         "Zhang & Karato, 1995\n(1300°C)",
                     ],
                 )
-                fig.savefig(_io.resolve_path(f"{out_basepath}.pdf"))
+                # There is a lot of stuff on this legend, so put it outside the axes.
+                # The 'loc' argument doesn't seem to work, use `bbox_to_anchor` instead.
+                # These values might need to be tweaked depending on the font size, etc.
+                _legend = _utils.redraw_legend(ax, fig=fig, bbox_to_anchor=(1.66, 0.99))
+                fig.savefig(
+                    _io.resolve_path(f"{out_basepath}.pdf"),
+                    bbox_extra_artists=(_legend,),
+                    bbox_inches="tight",
+                )
 
             # Check that GBM speeds up the alignment between 40% and 100% strain.
             _log.info("checking grain orientations...")


### PR DESCRIPTION
Produces the final version of the GBM vs fortran test as per overleaf manuscript.

The legend was overprinting traces at a font size of 18 so I moved it outside the axes.