### PR TITLE
2d shear calibration test

### DIFF
--- a/src/pydrex/diagnostics.py
+++ b/src/pydrex/diagnostics.py
@@ -15,7 +15,6 @@ r"""> PyDRex: Methods to calculate texture and strain diagnostics.
     grain axis and the j-th external axis (in the global Eulerian frame).
 
 """
-import os
 import functools as ft
 from multiprocessing import Pool
 

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -4,6 +4,7 @@ from matplotlib import projections as mproj
 from matplotlib import pyplot as plt
 from cmcrameri import cm as cmc
 
+from pydrex import core as _core
 from pydrex import axes as _axes
 from pydrex import io as _io
 from pydrex import logger as _log
@@ -451,12 +452,16 @@ def grainsizes(ax, strains, fractions):
     return fig, ax, parts
 
 
-def show_Skemer2016_ShearStrainAngles(ax, studies, markers, colors, fillstyles, labels):
+def show_Skemer2016_ShearStrainAngles(
+    ax, studies, markers, colors, fillstyles, labels, fabric
+):
     """Show data from `src/pydrex/data/thirdparty/Skemer2016_ShearStrainAngles.scsv`.
 
     Plot data from the Skemer 2016 datafile on the axis given by `ax`. Select the
     studies from which to plot the data, which must be a list of strings with exact
     matches in the `study` column in the datafile.
+    Also filter the data to select only the given `fabric`
+    (see `pydrex.core.MineralFabric`).
 
     If `ax` is None, a new figure and axes are created with `figure_unless`.
 
@@ -464,6 +469,13 @@ def show_Skemer2016_ShearStrainAngles(ax, studies, markers, colors, fillstyles, 
     the data series plots.
 
     """
+    fabric_map = {
+        _core.MineralFabric.olivine_A: "A",
+        _core.MineralFabric.olivine_B: "B",
+        _core.MineralFabric.olivine_C: "C",
+        _core.MineralFabric.olivine_D: "D",
+        _core.MineralFabric.olivine_E: "E",
+    }
     fig, ax = figure_unless(ax)
     data_Skemer2016 = _io.read_scsv(
         _io.data("thirdparty") / "Skemer2016_ShearStrainAngles.scsv"
@@ -472,7 +484,10 @@ def show_Skemer2016_ShearStrainAngles(ax, studies, markers, colors, fillstyles, 
         studies, markers, colors, fillstyles, labels, strict=True
     ):
         # Note: np.nonzero returns a tuple.
-        indices = np.nonzero(np.asarray(data_Skemer2016.study) == study)[0]
+        indices = np.nonzero(
+            np.asarray(data_Skemer2016.study) == study
+            and np.asarray(data_Skemer2016.fabric) == fabric_map[fabric]
+        )[0]
         ax.plot(
             np.take(data_Skemer2016.shear_strain, indices) / 200,
             np.take(data_Skemer2016.angle, indices),

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -485,8 +485,10 @@ def show_Skemer2016_ShearStrainAngles(
     ):
         # Note: np.nonzero returns a tuple.
         indices = np.nonzero(
-            np.asarray(data_Skemer2016.study) == study
-            and np.asarray(data_Skemer2016.fabric) == fabric_map[fabric]
+            np.logical_and(
+                np.asarray(data_Skemer2016.study) == study,
+                np.asarray(data_Skemer2016.fabric) == fabric_map[fabric],
+            )
         )[0]
         ax.plot(
             np.take(data_Skemer2016.shear_strain, indices) / 200,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
 """> Configuration and fixtures for PyDRex tests."""
-import os
-
 import matplotlib
 import pytest
 from _pytest.logging import LoggingPlugin, _LiveLoggingStreamHandler

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -652,7 +652,6 @@ class TestOlivineA:
                     ],
                 )
                 # There is a lot of stuff on this legend, so put it outside the axes.
-                # The 'loc' argument doesn't seem to work, use `bbox_to_anchor` instead.
                 # These values might need to be tweaked depending on the font size, etc.
                 _legend = _utils.redraw_legend(ax, fig=fig, bbox_to_anchor=(1.66, 0.99))
                 fig.savefig(

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -550,7 +550,8 @@ class TestOlivineA:
         _, get_velocity_gradient = _velocity.simple_shear_2d("Y", "X", strain_rate)
         timestamps = np.linspace(0, 5.5, 251)  # Solve until D₀t=5.5 ('shear' γ=11).
         params = _io.DEFAULT_PARAMS
-        gbm_mobilities = (10, 50, 125, 200)  # Must be in ascending order.
+        params["number_of_grains"] = 5000
+        gbm_mobilities = (1, 10, 50, 125)  # Must be in ascending order.
         markers = (".", "*", "d", "s")
         # Uses 100 seeds by default; use all 1000 if you have more RAM and CPU time.
         _seeds = seeds[:100]
@@ -631,6 +632,7 @@ class TestOlivineA:
                     markers,
                     labels,
                     err=result_angles_err,
+                    θ_max=80,
                 )
                 _vis.show_Skemer2016_ShearStrainAngles(
                     ax,
@@ -659,7 +661,7 @@ class TestOlivineA:
                 )
                 # There is a lot of stuff on this legend, so put it outside the axes.
                 # These values might need to be tweaked depending on the font size, etc.
-                _legend = _utils.redraw_legend(ax, fig=fig, bbox_to_anchor=(1.66, 0.99))
+                _legend = _utils.redraw_legend(ax, fig=fig, bbox_to_anchor=(1.77, 0.99))
                 fig.savefig(
                     _io.resolve_path(f"{out_basepath}.pdf"),
                     bbox_extra_artists=(_legend,),

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -541,9 +541,9 @@ class TestOlivineA:
 
         """
         shear_direction = [0, 1, 0]  # Used to calculate the angular diagnostics.
-        strain_rate = 1e-4
+        strain_rate = 1
         _, get_velocity_gradient = _velocity.simple_shear_2d("Y", "X", strain_rate)
-        timestamps = np.linspace(0, 1e4, 51)  # Solve until D₀t=1 ('shear' γ=2).
+        timestamps = np.linspace(0, 5.5, 251)  # Solve until D₀t=5.5 ('shear' γ=11).
         params = _io.DEFAULT_PARAMS
         gbm_mobilities = (10, 50, 125, 200)  # Must be in ascending order.
         markers = (".", "*", "d", "s")
@@ -651,4 +651,12 @@ class TestOlivineA:
                         "Hansen & Warren, 2015",
                     ],
                 )
-                fig.savefig(_io.resolve_path(f"{out_basepath}.pdf"))
+                # There is a lot of stuff on this legend, so put it outside the axes.
+                # The 'loc' argument doesn't seem to work, use `bbox_to_anchor` instead.
+                # These values might need to be tweaked depending on the font size, etc.
+                _legend = _utils.redraw_legend(ax, fig=fig, bbox_to_anchor=(1.66, 0.99))
+                fig.savefig(
+                    _io.resolve_path(f"{out_basepath}.pdf"),
+                    bbox_extra_artists=(_legend,),
+                    bbox_inches="tight",
+                )

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -327,6 +327,11 @@ class TestOlivineA:
                     }
                 ],
             }
+            np.savez(
+                f"{out_basepath}.npz",
+                angles=result_angles,
+                angles_err=result_angles_err,
+            )
             _io.save_scsv(
                 f"{out_basepath}_strains.scsv",
                 schema,
@@ -650,6 +655,7 @@ class TestOlivineA:
                         "Webber et al., 2010",
                         "Hansen & Warren, 2015",
                     ],
+                    fabric=_core.MineralFabric.olivine_A,
                 )
                 # There is a lot of stuff on this legend, so put it outside the axes.
                 # These values might need to be tweaked depending on the font size, etc.


### PR DESCRIPTION
Adds one more simple shear test showing all the relevant (A-type ~~and D-type~~) data from the compilation of Skemer & Hansen, 2016, Tectonophysics. I mention these data in the manuscript and he helpfully provided me with the raw data file so it doesn't hurt to include this.

This may help to choose which value of M* to recommend as default: the Kaminski & Ribe and Fraters & Billen choice of 125 or the Boneh et al. and Faccenda & VanderBeek choice of 10.