### PR TITLE
test: Add 3D shear test (Fraters 2021)

### DIFF
--- a/src/pydrex/cli.py
+++ b/src/pydrex/cli.py
@@ -82,13 +82,19 @@ class PoleFigureVisualiser:
                 mineral.orientations[i_range.start:i_range.stop:i_range.step],
                 mineral.fractions[i_range.start:i_range.stop:i_range.step],
             )
+            if args.scsv is None:
+                strains = None
+            else:
+                strains = _io.read_scsv(args.scsv).strain[
+                    i_range.start : i_range.stop : i_range.step
+                ]
             _vis.polefigures(
                 orientations_resampled,
                 ref_axes=args.ref_axes,
                 i_range=i_range,
                 density=args.density,
                 savefile=args.out,
-                strains=_io.read_scsv(args.scsv).strain,
+                strains=strains,
                 **density_kwargs,
             )
         except (argparse.ArgumentError, ValueError, _err.Error) as e:

--- a/src/pydrex/mock.py
+++ b/src/pydrex/mock.py
@@ -10,7 +10,7 @@ PARAMS_FRATERS2021 = {
     "gbm_mobility": 125,
     "gbs_threshold": 0.3,
     "nucleation_efficiency": 5,
-    "number_of_grains": 500,
+    "number_of_grains": 5000,
 }
 """Values used for tests 1, 2 and 4 in <https://doi.org/10.1029/2021gc009846>."""
 

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -612,4 +612,4 @@ def figure(**kwargs):
     (e.g. grid, constrained layout, high DPI).
 
     """
-    return plt.figure()
+    return plt.figure(**kwargs)

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -151,12 +151,12 @@ def pathline_box2d(
     min_coords,
     max_coords,
     resolution,
-    scale=None,
     aspect="equal",
     cmap=cmc.batlow,
     cpo_vectors=None,
     cpo_strengths=None,
     tick_formatter=lambda x, pos: f"{x/1e3:.1f} km",
+    **kwargs,
 ):
     """Plot pathlines and velocity arrows for a 2D box domain.
 
@@ -174,12 +174,14 @@ def pathline_box2d(
     - `resolution` (array) — 2D resolution of the velocity arrow grid (i.e. number of
       grid points in the horizontal and vertical directions) which can be set to None to
       prevent drawing velocity vectors
-    - `scale` (float, optional) — scale factor for the velocity arrows
     - `aspect` (str|float, optional) — see `matplotlib.axes.Axes.set_aspect`
     - `cmap` (Matplotlib color map, optional) — color map for `colors`
     - `cpo_vectors` (array, optional) — vectors to plot as bars at pathline locations
     - `cpo_strengths` (array, optional) — strengths used to scale the cpo bars
     - `tick_formatter` (callable, optional) — function used to format tick labels
+
+    Additional keyword arguments are passed to the `matplotlib.axex.Axes.quiver` call
+    used to plot the velocity vectors.
 
     Returns the figure handle, the axes handle, the quiver collection (velocities) and
     the scatter collection (pathline).
@@ -226,7 +228,7 @@ def pathline_box2d(
             V.reshape(Y_grid.shape),
             pivot="mid",
             alpha=0.25,
-            scale=scale,
+            **kwargs,
         )
 
     P = np.asarray([[p[horizontal], p[vertical]] for p in positions])

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -180,7 +180,7 @@ def pathline_box2d(
     - `cpo_strengths` (array, optional) — strengths used to scale the cpo bars
     - `tick_formatter` (callable, optional) — function used to format tick labels
 
-    Additional keyword arguments are passed to the `matplotlib.axex.Axes.quiver` call
+    Additional keyword arguments are passed to the `matplotlib.axes.Axes.quiver` call
     used to plot the velocity vectors.
 
     Returns the figure handle, the axes handle, the quiver collection (velocities) and

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -40,6 +40,10 @@ def polefigures(
     on the command line.
 
     """
+    if len(orientations) != len(i_range):
+        raise ValueError("mismatched length of 'orientations' and 'i_range'")
+    if strains is not None and len(strains) != len(i_range):
+        raise ValueError("mismatched length of 'strains'")
     n_orientations = len(orientations)
     fig = plt.figure(figsize=(n_orientations, 4), dpi=600)
 
@@ -64,11 +68,11 @@ def polefigures(
             ax_strain.set_xticks(list(i_range))
         else:
             fig_strain.suptitle("strain (%)", x=0.5, y=0.85, fontsize="small")
-            ax_strain.set_xticks(strains[i_range.start : i_range.stop : i_range.step])
+            ax_strain.set_xticks(strains)
             ax_strain.set_xlim(
                 (
-                    strains[i_range.start] - strains[i_range.step] / 2,
-                    strains[i_range.stop - i_range.step] + strains[i_range.step] / 2,
+                    strains[0] - strains[1] / 2,
+                    strains[-1] + strains[1] / 2,
                 )
             )
 

--- a/tests/test_corner_flow_2d.py
+++ b/tests/test_corner_flow_2d.py
@@ -200,6 +200,8 @@ class TestCornerOlivineA:
                     cmap=cmaps[i],
                     cpo_vectors=directions[i],
                     cpo_strengths=indices[i],
+                    scale=25,
+                    scale_units="width",
                 )
 
             fig_strength, ax_strength, colors = _vis.strengths(

--- a/tests/test_simple_shear_3d.py
+++ b/tests/test_simple_shear_3d.py
@@ -103,7 +103,7 @@ class TestFraters2021:
         return olivine, enstatite
 
     @pytest.mark.slow
-    @pytest.mark.parametrize("switch_time_Ma", [0, 0.5, 1.25, np.inf])
+    @pytest.mark.parametrize("switch_time_Ma", [0, 1, 2.5, np.inf])
     def test_direction_change(
         self, outdir, seeds, params_Fraters2021, switch_time_Ma, ncpus
     ):

--- a/tests/test_simple_shear_3d.py
+++ b/tests/test_simple_shear_3d.py
@@ -153,7 +153,7 @@ class TestFraters2021:
                 timestamps,
                 get_velocity_gradient_initial,
                 get_velocity_gradient_final,
-                switch_time_Ma,
+                switch_time_Ma * 1e6,
                 _id,
             )
             with Pool(processes=ncpus) as pool:

--- a/tests/test_simple_shear_3d.py
+++ b/tests/test_simple_shear_3d.py
@@ -157,11 +157,11 @@ class TestFraters2021:
                 _id,
             )
             with Pool(processes=ncpus) as pool:
-                for s, out in enumerate(pool.imap_unordered(_run, seeds)):
+                for s, out in enumerate(pool.imap_unordered(_run, _seeds)):
                     olivine, enstatite = out
-                    _log.info("%s; # %d; postprocessing olivine...", _id, seeds[s])
+                    _log.info("%s; # %d; postprocessing olivine...", _id, _seeds[s])
                     olA_resampled, _ = _stats.resample_orientations(
-                        olivine.orientations, olivine.fractions, seed=seeds[s]
+                        olivine.orientations, olivine.fractions, seed=_seeds[s]
                     )
                     olA_mean_vectors = np.array(
                         [
@@ -183,9 +183,9 @@ class TestFraters2021:
                     )
                     del olivine, olA_resampled, olA_mean_vectors
 
-                    _log.info("%s; # %d; postprocessing enstatite...", _id, seeds[s])
+                    _log.info("%s; # %d; postprocessing enstatite...", _id, _seeds[s])
                     ens_resampled, _ = _stats.resample_orientations(
-                        enstatite.orientations, enstatite.fractions, seed=seeds[s]
+                        enstatite.orientations, enstatite.fractions, seed=_seeds[s]
                     )
                     ens_mean_vectors = np.array(
                         [

--- a/tests/test_simple_shear_3d.py
+++ b/tests/test_simple_shear_3d.py
@@ -187,8 +187,11 @@ class TestFraters2021:
                     ens_resampled, _ = _stats.resample_orientations(
                         enstatite.orientations, enstatite.fractions, seed=seeds[s]
                     )
-                    ens_mean_vectors = _diagnostics.bingham_average(
-                        ens_resampled, axis="a"
+                    ens_mean_vectors = np.array(
+                        [
+                            _diagnostics.bingham_average(dcm, axis="a")
+                            for dcm in ens_resampled
+                        ]
                     )
                     ens_from_proj_XZ[s, :] = np.array(
                         [

--- a/tests/test_simple_shear_3d.py
+++ b/tests/test_simple_shear_3d.py
@@ -1,0 +1,234 @@
+"""> PyDRex: Simple shear 3D tests."""
+import contextlib as cl
+import numpy as np
+from multiprocessing import Pool
+from time import process_time
+import functools as ft
+
+import pytest
+
+from pydrex import core as _core
+from pydrex import logger as _log
+from pydrex import minerals as _minerals
+from pydrex import velocity as _velocity
+from pydrex import stats as _stats
+from pydrex import diagnostics as _diagnostics
+from pydrex import utils as _utils
+from pydrex import io as _io
+
+# Subdirectory of `outdir` used to store outputs from these tests.
+SUBDIR = "3d_simple_shear"
+
+
+class TestFraters2021:
+    """Tests inspired by the benchmarks presented in [Fraters & Billen, 2021].
+
+    [Fraters & Billen, 2021]: https://doi.org/10.1029/2021GC009846
+
+    """
+
+    class_id = "Fraters2021"
+
+    @classmethod
+    def run(
+        cls,
+        params,
+        timestamps,
+        get_velocity_gradient_initial,
+        get_velocity_gradient_final,
+        switch_time,
+        msg,
+        seed=None,
+    ):
+        """Run simulation with stationary particles in the given velocity gradient.
+
+        The optional RNG `seed` is used for the initial pseudorandom orientations.
+        A prefix `msg` will be printed before each timestep log message if given.
+        Other keyword args are passed to `pydrex.Mineral.update_orientations`.
+
+        Returns a tuple containing one olivine (A-type) and one enstatite mineral.
+        If `params["enstatite_fraction"]` is zero, then the second tuple element will be
+        `None` instead.
+
+        """
+
+        def get_position(t):
+            return np.full(3, np.nan)
+
+        olivine = _minerals.Mineral(
+            phase=_core.MineralPhase.olivine,
+            fabric=_core.MineralFabric.olivine_A,
+            regime=_core.DeformationRegime.dislocation,
+            n_grains=params["number_of_grains"],
+            seed=seed,
+        )
+        if params["enstatite_fraction"] > 0:
+            enstatite = _minerals.Mineral(
+                phase=_core.MineralPhase.enstatite,
+                fabric=_core.MineralFabric.enstatite_AB,
+                regime=_core.DeformationRegime.dislocation,
+                n_grains=params["number_of_grains"],
+                seed=seed,
+            )
+        else:
+            enstatite = None
+        deformation_gradient = np.eye(3)  # Undeformed initial state.
+
+        for t, time in enumerate(timestamps[:-1], start=1):
+            _log.info(
+                "%s; # %d; step %d/%d (t = %s)", msg, seed, t, len(timestamps) - 1, time
+            )
+            if time > switch_time:
+                get_velocity_gradient = get_velocity_gradient_final
+            else:
+                get_velocity_gradient = get_velocity_gradient_initial
+
+            if params["enstatite_fraction"] > 0:
+                enstatite.update_orientations(
+                    params,
+                    deformation_gradient,
+                    get_velocity_gradient,
+                    pathline=(time, timestamps[t], get_position),
+                )
+            deformation_gradient = olivine.update_orientations(
+                params,
+                deformation_gradient,
+                get_velocity_gradient,
+                pathline=(time, timestamps[t], get_position),
+            )
+            _log.debug(
+                "› velocity gradient = %s",
+                get_velocity_gradient(None).flatten(),
+            )
+        return olivine, enstatite
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("switch_time_Ma", [0, 0.5, 1.25, np.inf])
+    def test_direction_change(
+        self, outdir, seeds, params_Fraters2021, switch_time_Ma, ncpus
+    ):
+        """Test a-axis alignment in simple shear with instantaneous geometry change.
+
+        The simulation runs for 5 Ma with a strain rate of 1.58e-14/s, resulting in an
+        accumulated strain invariant of 2.5.
+
+        The initial shear has nonzero du/dz and the final shear has nonzero dv/dx where
+        u is the velocity along X and v the velocity along Y.
+
+        """
+        # Strain rate in units of strain per year, avoids tiny numbers ∼1e-14.
+        strain_rate = 5e-7
+        # With 500 steps, each step is ~3e11 seconds which is about as small as
+        # geodynamic modelling could feasibly go in most cases.
+        n_timestamps = 500
+        # Solve until D₀t=2.5 ('shear' γ=5).
+        timestamps = np.linspace(0, 5e6, n_timestamps)
+        _seeds = seeds[:500]  # 500 runs as per Fraters & Billen, 2021, Figure 5.
+        n_seeds = len(_seeds)
+
+        _, get_velocity_gradient_initial = _velocity.simple_shear_2d(
+            "X", "Z", strain_rate
+        )
+        _, get_velocity_gradient_final = _velocity.simple_shear_2d(
+            "Y", "X", strain_rate
+        )
+
+        # Output arrays for mean [100] angles.
+        olA_from_proj_XZ = np.empty((n_seeds, n_timestamps))
+        olA_from_proj_YX = np.empty_like(olA_from_proj_XZ)
+        ens_from_proj_XZ = np.empty_like(olA_from_proj_XZ)
+        ens_from_proj_YX = np.empty_like(olA_from_proj_XZ)
+
+        _id = _io.stringify(switch_time_Ma * 1e6)
+        optional_logging = cl.nullcontext()
+        if outdir is not None:
+            out_basepath = f"{outdir}/{SUBDIR}/{self.class_id}_direction_change_{_id}"
+            optional_logging = _log.logfile_enable(f"{out_basepath}.log")
+
+        with optional_logging:
+            clock_start = process_time()
+            _run = ft.partial(
+                self.run,
+                params_Fraters2021,
+                timestamps,
+                get_velocity_gradient_initial,
+                get_velocity_gradient_final,
+                switch_time_Ma,
+                _id,
+            )
+            with Pool(processes=ncpus) as pool:
+                for s, out in enumerate(pool.imap_unordered(_run, seeds)):
+                    olivine, enstatite = out
+                    _log.info("%s; # %d; postprocessing olivine...", _id, seeds[s])
+                    olA_resampled, _ = _stats.resample_orientations(
+                        olivine.orientations, olivine.fractions, seed=seeds[s]
+                    )
+                    olA_mean_vectors = np.array(
+                        [
+                            _diagnostics.bingham_average(dcm, axis="a")
+                            for dcm in olA_resampled
+                        ]
+                    )
+                    olA_from_proj_XZ[s, :] = np.array(
+                        [
+                            _diagnostics.smallest_angle(v, v - v * [0, 1, 0])
+                            for v in olA_mean_vectors
+                        ]
+                    )
+                    olA_from_proj_YX[s, :] = np.array(
+                        [
+                            _diagnostics.smallest_angle(v, v - v * [0, 0, 1])
+                            for v in olA_mean_vectors
+                        ]
+                    )
+                    del olivine, olA_resampled, olA_mean_vectors
+
+                    _log.info("%s; # %d; postprocessing enstatite...", _id, seeds[s])
+                    ens_resampled, _ = _stats.resample_orientations(
+                        enstatite.orientations, enstatite.fractions, seed=seeds[s]
+                    )
+                    ens_mean_vectors = _diagnostics.bingham_average(
+                        ens_resampled, axis="a"
+                    )
+                    ens_from_proj_XZ[s, :] = np.array(
+                        [
+                            _diagnostics.smallest_angle(v, v - v * [0, 1, 0])
+                            for v in ens_mean_vectors
+                        ]
+                    )
+                    ens_from_proj_YX[s, :] = np.array(
+                        [
+                            _diagnostics.smallest_angle(v, v - v * [0, 0, 1])
+                            for v in ens_mean_vectors
+                        ]
+                    )
+
+            _log.info(
+                "elapsed CPU time: %s",
+                _utils.readable_timestamp(np.abs(process_time() - clock_start)),
+            )
+            _log.info("calculating ensemble averages...")
+            olA_from_proj_XZ_mean = olA_from_proj_XZ.mean(axis=0)
+            olA_from_proj_XZ_err = olA_from_proj_XZ.std(axis=0)
+
+            olA_from_proj_YX_mean = olA_from_proj_YX.mean(axis=0)
+            olA_from_proj_YX_err = olA_from_proj_YX.std(axis=0)
+
+            ens_from_proj_XZ_mean = ens_from_proj_XZ.mean(axis=0)
+            ens_from_proj_XZ_err = ens_from_proj_XZ.std(axis=0)
+
+            ens_from_proj_YX_mean = ens_from_proj_YX.mean(axis=0)
+            ens_from_proj_YX_err = ens_from_proj_YX.std(axis=0)
+
+            if outdir is not None:
+                np.savez(
+                    f"{out_basepath}.npz",
+                    olA_from_proj_XZ_mean=olA_from_proj_XZ_mean,
+                    olA_from_proj_XZ_err=olA_from_proj_XZ_err,
+                    olA_from_proj_YX_mean=olA_from_proj_YX_mean,
+                    olA_from_proj_YX_err=olA_from_proj_YX_err,
+                    ens_from_proj_XZ_mean=ens_from_proj_XZ_mean,
+                    ens_from_proj_XZ_err=ens_from_proj_XZ_err,
+                    ens_from_proj_YX_mean=ens_from_proj_YX_mean,
+                    ens_from_proj_YX_err=ens_from_proj_YX_err,
+                )


### PR DESCRIPTION
Test inspired by Fraters 2021 Fig 5 but now with the correct angle projections. No figure by default because it's an ensemble, instead the data for both plots is saved for each switch time, plotting just requires loading the saved data and giving it to `visualisation.alignment`.

Other stuff included here:
- small fix to the pole figure plotting function for correct use of the optional `strains.scsv` files in some tests
- fix typo in number of grains in `mock.params_Fraters2021` (500 -> 5000)