### PR TITLE
Add 2D advection test

### DIFF
--- a/src/pydrex/diagnostics.py
+++ b/src/pydrex/diagnostics.py
@@ -355,8 +355,8 @@ def coaxial_index(orientations, axis1="b", axis2="a"):
     fluctuations compared to the raw eigenvalue diagnostics.
 
     """
-    P1, G1, _ = symmetry(orientations, axis=axis1)
-    P2, G2, _ = symmetry(orientations, axis=axis2)
+    P1, G1, _ = symmetry_pgr(orientations, axis=axis1)
+    P2, G2, _ = symmetry_pgr(orientations, axis=axis2)
     return 0.5 * (2 - (P1 / (G1 + P1)) - (G2 / (G2 + P2)))
 
 

--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -267,18 +267,18 @@ class Mineral:
         else:
             shape_of_orientations = "(?)"
 
-        return (
-            self.__class__.__qualname__
-            + f"(phase={self.phase!s}, "
-            + f"fabric={self.fabric!s}, "
-            + f"regime={self.regime!s}, "
-            + f"n_grains={self.n_grains!s}, "
-            + f"fractions=<{self.fractions.__class__.__qualname__}"
-            + f" of {self.fractions[0].__class__.__qualname__} {shape_of_fractions}>, "
-            + f"orientations=<{self.orientations.__class__.__qualname__}"
-            + f" of {self.orientations[0].__class__.__qualname__}"
-            + f" {shape_of_orientations}>)"
-        )
+        obj = self.__class__.__qualname__
+        phase = f"(phase={self.phase!r}, "
+        fabric = f"fabric={self.fabric!r}, "
+        regime = f"regime={self.regime!r}, "
+        n_grains = f"n_grains={self.n_grains}, "
+        _fclass = self.fractions.__class__.__qualname__
+        _f0class = self.fractions[0].__class__.__qualname__
+        frac = f"fractions=<{_fclass} of {_f0class} {shape_of_fractions}>, "
+        _oclass = self.orientations.__class__.__qualname__
+        _o0class = self.orientations[0].__class__.__qualname__
+        orient = f"orientations=<{_oclass} of {_o0class} {shape_of_orientations}>)"
+        return f"{obj}{phase}{fabric}{regime}{n_grains}{frac}{orient}"
 
     def _repr_pretty_(self, p, cycle):
         # Format to use when printing to IPython or other interactive console.
@@ -367,7 +367,9 @@ class Mineral:
             elif self.phase == _core.MineralPhase.enstatite:
                 volume_fraction = config["enstatite_fraction"]
             else:
-                assert False  # Should never happen.
+                raise ValueError(
+                    f"phase must be a valid `MineralPhase`, not {self.phase}"
+                )
 
             strain_rate = (velocity_gradient + velocity_gradient.transpose()) / 2
             strain_rate_max = np.abs(la.eigvalsh(strain_rate)).max()

--- a/src/pydrex/pathlines.py
+++ b/src/pydrex/pathlines.py
@@ -107,8 +107,8 @@ def get_pathline(
         "calculated pathline from %s (t = %e) to %s (t = %e)",
         path.sol(path.t[0]),
         path.t[0],
-        path.sol(path.t[-2]),
-        path.t[-2],
+        path.sol(path.t[-1]),
+        path.t[-1],
     )
 
     if regular_steps is None:

--- a/src/pydrex/pathlines.py
+++ b/src/pydrex/pathlines.py
@@ -14,6 +14,7 @@ def get_pathline(
     min_coords,
     max_coords,
     max_strain,
+    regular_steps=None,
     **kwargs,
 ):
     """Determine the pathline for a particle in a steady state flow.
@@ -37,6 +38,10 @@ def get_pathline(
       location, useful if the pathline never inflows into the domain (the pathline will
       only be traced backwards until a strain of 0 is reached, unless a domain boundary
       is reached first)
+    - `regular_steps` (float, optional) — number of time steps to use for regular
+      resampling between the start (t << 0) and end (t <= 0) of the pathline
+      (if `None`, which is the default, then the timestamps obtained from
+      `scipy.integrate.solve_ivp` are returned instead)
 
     Optional keyword arguments will be passed to `scipy.integrate.solve_ivp`. However,
     some of the arguments to the `solve_ivp` call may not be modified, and a warning
@@ -106,8 +111,10 @@ def get_pathline(
         path.t[-2],
     )
 
-    # Remove the last timestep — integration stops one step after a terminal event.
-    return path.t[:-1], path.sol
+    if regular_steps is None:
+        return path.t[::-1], path.sol
+    else:
+        return np.linspace(path.t[-1], path.t[0], regular_steps + 1), path.sol
 
 
 def _ivp_func(time, point, get_velocity, get_velocity_gradient, min_coords, max_coords):

--- a/src/pydrex/utils.py
+++ b/src/pydrex/utils.py
@@ -93,21 +93,21 @@ def default_ncpus():
         return 1
 
 
-def get_steps(a):
+def diff_like(a):
     """Get forward difference of 2D array `a`, with repeated last elements.
 
     The repeated last elements ensure that output and input arrays have equal shape.
 
     Examples:
 
-    >>> get_steps(np.array([1, 2, 3, 4, 5]))
+    >>> diff_like(np.array([1, 2, 3, 4, 5]))
     array([[1, 1, 1, 1, 1]])
 
-    >>> get_steps(np.array([[1, 2, 3, 4, 5], [1, 3, 6, 9, 10]]))
+    >>> diff_like(np.array([[1, 2, 3, 4, 5], [1, 3, 6, 9, 10]]))
     array([[1, 1, 1, 1, 1],
            [2, 3, 3, 1, 1]])
 
-    >>> get_steps(np.array([[1, 2, 3, 4, 5], [1, 3, 6, 9, 10], [1, 0, 0, 0, np.inf]]))
+    >>> diff_like(np.array([[1, 2, 3, 4, 5], [1, 3, 6, 9, 10], [1, 0, 0, 0, np.inf]]))
     array([[ 1.,  1.,  1.,  1.,  1.],
            [ 2.,  3.,  3.,  1.,  1.],
            [-1.,  0.,  0., inf, nan]])

--- a/src/pydrex/velocity.py
+++ b/src/pydrex/velocity.py
@@ -122,8 +122,8 @@ def simple_shear_2d(direction, deformation_plane, strain_rate):
     Args:
     - `direction` (one of {"X", "Y", "Z"}) — velocity vector direction
     - `deformation_plane` (one of {"X", "Y", "Z"}) — direction of velocity gradient
-    - `strain_rate` (float) — 1/2 × strength of velocity gradient (i.e. magnitude of the
-      velocity at a unit distance from the shear plane)
+    - `strain_rate` (float) — 1/2 × magnitude of the largest eigenvalue of the velocity
+      gradient
 
     .. note::
         Input arrays to the returned callables must have homogeneous element types.

--- a/tests/test_corner_flow_2d.py
+++ b/tests/test_corner_flow_2d.py
@@ -52,15 +52,15 @@ class TestCornerOlivineA:
             seed=seed,
         )
         deformation_gradient = np.eye(3)
-        timestamps_back, get_position = _path.get_pathline(
+        timestamps, get_position = _path.get_pathline(
             final_location,
             get_velocity,
             get_velocity_gradient,
             min_coords,
             max_coords,
             max_strain,
+            regular_steps=n_timesteps,
         )
-        timestamps = np.linspace(timestamps_back[-1], timestamps_back[0], n_timesteps)
         positions = [get_position(t) for t in timestamps]
         velocity_gradients = [get_velocity_gradient(np.asarray(x)) for x in positions]
         strains = np.empty_like(timestamps)

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -850,7 +850,9 @@ class TestOlivineA:
             nt.assert_array_less(np.diff(cpo_angles[1:]), np.ones(n_timesteps - 1))
             # Check for increasing CPO strength (M-index).
             _log.debug("cpo strengths: %s", misorient_indices)
-            nt.assert_array_less(np.zeros(n_timesteps), np.diff(misorient_indices))
+            nt.assert_array_less(
+                np.full(n_timesteps, -0.01), np.diff(misorient_indices)
+            )
             # Check that last angle is <5° (M*=125) or <10° (M*=10).
             assert cpo_angles[-1] < 5
 

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -847,7 +847,7 @@ class TestOlivineA:
 
             # Check for mostly decreasing CPO angles (exclude initial condition).
             _log.debug("cpo angles: %s", cpo_angles)
-            nt.assert_array_less(np.diff(cpo_angles[1:]), np.ones(n_timesteps))
+            nt.assert_array_less(np.diff(cpo_angles[1:]), np.ones(n_timesteps - 1))
             # Check for increasing CPO strength (M-index).
             _log.debug("cpo strengths: %s", misorient_indices)
             nt.assert_array_less(np.zeros(n_timesteps), np.diff(misorient_indices))

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -7,14 +7,18 @@ from time import process_time
 
 import numpy as np
 import pytest
+from numpy import asarray as Ŋ
 from numpy import testing as nt
 from scipy.interpolate import PchipInterpolator
 
 from pydrex import core as _core
 from pydrex import diagnostics as _diagnostics
+from pydrex import geometry as _geo
 from pydrex import io as _io
 from pydrex import logger as _log
 from pydrex import minerals as _minerals
+from pydrex import pathlines as _paths
+from pydrex import stats as _stats
 from pydrex import utils as _utils
 from pydrex import velocity as _velocity
 from pydrex import visualisation as _vis
@@ -23,14 +27,90 @@ from pydrex import visualisation as _vis
 SUBDIR = "2d_simple_shear"
 
 
+class TestPreliminaries:
+    """Preliminary tests to check that various auxiliary routines are working."""
+
+    def test_strain_increment(self):
+        """Test for accumulating strain via strain increment calculations."""
+        _, get_velocity_gradient = _velocity.simple_shear_2d("X", "Z", 1)
+        timestamps = np.linspace(0, 1, 10)  # Solve until D₀t=1 (tensorial strain).
+        strains_inc = np.zeros_like(timestamps)
+        L = get_velocity_gradient(Ŋ([0e0, 0e0, 0e0]))
+        for i, ε in enumerate(strains_inc[1:]):
+            strains_inc[i + 1] = strains_inc[i] + _utils.strain_increment(
+                timestamps[1] - timestamps[0],
+                L,
+            )
+        # For constant timesteps, check strains == positive_timestamps * strain_rate.
+        nt.assert_allclose(strains_inc, timestamps, atol=6e-16, rtol=0)
+
+        # Same thing, but for strain rate similar to experiments.
+        _, get_velocity_gradient = _velocity.simple_shear_2d("Y", "X", 1e-5)
+        timestamps = np.linspace(0, 1e6, 10)  # Solve until D₀t=10 (tensorial strain).
+        strains_inc = np.zeros_like(timestamps)
+        L = get_velocity_gradient(Ŋ([0e0, 0e0, 0e0]))
+        for i, ε in enumerate(strains_inc[1:]):
+            strains_inc[i + 1] = strains_inc[i] + _utils.strain_increment(
+                timestamps[1] - timestamps[0],
+                L,
+            )
+        nt.assert_allclose(strains_inc, timestamps * 1e-5, atol=5e-15, rtol=0)
+
+        # Again, but this time the particle will move (using get_pathline).
+        # We use a 400km x 400km box and a strain rate of 1e-15 s⁻¹.
+        get_velocity, get_velocity_gradient = _velocity.simple_shear_2d("X", "Z", 1e-15)
+        timestamps, get_position = _paths.get_pathline(
+            Ŋ([1e5, 0e0, 1e5]),
+            get_velocity,
+            get_velocity_gradient,
+            Ŋ([-2e5, 0e0, -2e5]),
+            Ŋ([2e5, 0e0, 2e5]),
+            2,
+            regular_steps=10,
+        )
+        positions = [get_position(t) for t in timestamps]
+        velocity_gradients = [get_velocity_gradient(Ŋ(x)) for x in positions]
+
+        # Check that polycrystal is experiencing steady velocity gradient.
+        nt.assert_array_equal(
+            velocity_gradients, np.full_like(velocity_gradients, velocity_gradients[0])
+        )
+        # Check that positions are changing as expected.
+        xdiff = np.diff(Ŋ([x[0] for x in positions]))
+        zdiff = np.diff(Ŋ([x[2] for x in positions]))
+        assert xdiff[0] > 0
+        assert zdiff[0] == 0
+        nt.assert_allclose(xdiff, np.full_like(xdiff, xdiff[0]), rtol=0, atol=1e-10)
+        nt.assert_allclose(zdiff, np.full_like(zdiff, zdiff[0]), rtol=0, atol=1e-10)
+        strains_inc = np.zeros_like(timestamps)
+        for t, time in enumerate(timestamps[:-1], start=1):
+            strains_inc[t] = strains_inc[t - 1] + (
+                _utils.strain_increment(timestamps[t] - time, velocity_gradients[t])
+            )
+        # fig, ax, _, _ = _vis.pathline_box2d(
+        #     None,
+        #     get_velocity,
+        #     "xz",
+        #     strains_inc,
+        #     positions,
+        #     ".",
+        #     Ŋ([-2e5, -2e5]),
+        #     Ŋ([2e5, 2e5]),
+        #     [20, 20],
+        # )
+        # fig.savefig("/tmp/fig.png")
+        nt.assert_allclose(
+            strains_inc,
+            (timestamps - timestamps[0]) * 1e-15,
+            atol=5e-15,
+            rtol=0,
+        )
+
+
 class TestOlivineA:
     """Tests for stationary A-type olivine polycrystals in 2D simple shear."""
 
     class_id = "olivineA"
-
-    @classmethod
-    def get_position(cls, t):
-        return np.zeros(3)  # These crystals are stationary.
 
     @classmethod
     def run(
@@ -42,6 +122,7 @@ class TestOlivineA:
         shear_direction,
         seed=None,
         return_fse=None,
+        get_position=lambda t: np.zeros(3),  # Stationary particles by default.
     ):
         """Reusable logic for 2D olivine (A-type) simple shear tests.
 
@@ -77,7 +158,7 @@ class TestOlivineA:
                 params,
                 deformation_gradient,
                 get_velocity_gradient,
-                pathline=(time, timestamps[t], cls.get_position),
+                pathline=(time, timestamps[t], get_position),
             )
             _log.debug(
                 "› velocity gradient = %s",
@@ -698,3 +779,91 @@ class TestOlivineA:
                 _log.info(
                     "Sums of squared residuals (r-values) for each M∗: %s", r2vals
                 )
+
+    @pytest.mark.big
+    def test_dudz_pathline(self, outdir, seed):
+        """Test alignment of olivine a-axis for a polycrystal advected on a pathline."""
+        test_id = "dudz_pathline"
+        optional_logging = cl.nullcontext()
+        if outdir is not None:
+            out_basepath = f"{outdir}/{SUBDIR}/{self.class_id}_{test_id}"
+            optional_logging = _log.logfile_enable(f"{out_basepath}.log")
+
+        with optional_logging:
+            shear_direction = [0, 1, 0]  # Used to calculate the angular diagnostics.
+            strain_rate = 1e-15  # Moderate, realistic shear in the upper mantle.
+            get_velocity, get_velocity_gradient = _velocity.simple_shear_2d(
+                "X", "Z", strain_rate
+            )
+            n_timesteps = 10
+            timestamps, get_position = _paths.get_pathline(
+                Ŋ([1e5, 0e0, 1e5]),
+                get_velocity,
+                get_velocity_gradient,
+                Ŋ([-2e5, 0e0, -2e5]),
+                Ŋ([2e5, 0e0, 2e5]),
+                2,
+                regular_steps=n_timesteps,
+            )
+            positions = [get_position(t) for t in timestamps]
+            velocity_gradients = [get_velocity_gradient(Ŋ(x)) for x in positions]
+
+            params = _io.DEFAULT_PARAMS
+            params["number_of_grains"] = 5000
+            olA = _minerals.Mineral(n_grains=params["number_of_grains"], seed=seed)
+            deformation_gradient = np.eye(3)
+            strains = np.zeros_like(timestamps)
+            for t, time in enumerate(timestamps[:-1], start=1):
+                strains[t] = strains[t - 1] + (
+                    _utils.strain_increment(timestamps[t] - time, velocity_gradients[t])
+                )
+                _log.info("step %d/%d (ε = %.2f)", t, len(timestamps) - 1, strains[t])
+                deformation_gradient = olA.update_orientations(
+                    params,
+                    deformation_gradient,
+                    get_velocity_gradient,
+                    pathline=(time, timestamps[t], get_position),
+                )
+
+            orient_resampled, fractions_resampled = _stats.resample_orientations(
+                olA.orientations, olA.fractions, seed=seed
+            )
+            # About 36GB, 26 min needed with float64. GitHub macos runner has 14GB.
+            misorient_indices = _diagnostics.misorientation_indices(
+                orient_resampled,
+                _geo.LatticeSystem.orthorhombic,
+                ncpus=3,
+            )
+            cpo_vectors = np.zeros((n_timesteps + 1, 3))
+            cpo_angles = np.zeros(n_timesteps + 1)
+            for i, matrices in enumerate(orient_resampled):
+                cpo_vectors[i] = _diagnostics.bingham_average(
+                    matrices,
+                    axis=_minerals.OLIVINE_PRIMARY_AXIS[olA.fabric],
+                )
+                cpo_angles[i] = _diagnostics.smallest_angle(
+                    cpo_vectors[i], Ŋ(shear_direction, dtype=np.float64)
+                )
+
+            # Check for decreasing CPO angles (exclude initial condition).
+            nt.assert_array_less(np.diff(cpo_angles[1:]), np.zeros(n_timesteps))
+            # Check for increasing CPO strength (M-index).
+            nt.assert_array_less(np.zeros(n_timesteps), np.diff(misorient_indices))
+            # Check that last angle is <5° (M*=125) or <10° (M*=10).
+            assert cpo_angles[-1] < 5
+
+        if outdir is not None:
+            fig, ax, _, _ = _vis.pathline_box2d(
+                None,
+                get_velocity,
+                "xz",
+                strains,
+                positions,
+                ".",
+                Ŋ([-2e5, -2e5]),
+                Ŋ([2e5, 2e5]),
+                [20, 20],
+                cpo_vectors=cpo_vectors,
+                cpo_strengths=misorient_indices,
+            )
+            fig.savefig(f"{out_basepath}.pdf")

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -790,7 +790,7 @@ class TestOlivineA:
             optional_logging = _log.logfile_enable(f"{out_basepath}.log")
 
         with optional_logging:
-            shear_direction = [0, 1, 0]  # Used to calculate the angular diagnostics.
+            shear_direction = [1, 0, 0]  # Used to calculate the angular diagnostics.
             strain_rate = 1e-15  # Moderate, realistic shear in the upper mantle.
             get_velocity, get_velocity_gradient = _velocity.simple_shear_2d(
                 "X", "Z", strain_rate
@@ -845,9 +845,11 @@ class TestOlivineA:
                     cpo_vectors[i], Ŋ(shear_direction, dtype=np.float64)
                 )
 
-            # Check for decreasing CPO angles (exclude initial condition).
-            nt.assert_array_less(np.diff(cpo_angles[1:]), np.zeros(n_timesteps))
+            # Check for mostly decreasing CPO angles (exclude initial condition).
+            _log.debug("cpo angles: %s", cpo_angles)
+            nt.assert_array_less(np.diff(cpo_angles[1:]), np.ones(n_timesteps))
             # Check for increasing CPO strength (M-index).
+            _log.debug("cpo strengths: %s", misorient_indices)
             nt.assert_array_less(np.zeros(n_timesteps), np.diff(misorient_indices))
             # Check that last angle is <5° (M*=125) or <10° (M*=10).
             assert cpo_angles[-1] < 5

--- a/tests/test_vortex_2d.py
+++ b/tests/test_vortex_2d.py
@@ -91,16 +91,14 @@ class TestCellOlivineA:
         )
         deformation_gradient = np.eye(3)
 
-        timestamps_back, get_position = _path.get_pathline(
+        timestamps, get_position = _path.get_pathline(
             final_location,
             get_velocity,
             get_velocity_gradient,
             min_coords,
             max_coords,
             max_strain,
-        )
-        timestamps = np.linspace(
-            timestamps_back[-1], timestamps_back[0], int(max_strain * 10)
+            regular_steps=int(max_strain * 10),
         )
         positions = [get_position(t) for t in timestamps]
         velocity_gradients = [get_velocity_gradient(np.asarray(x)) for x in positions]


### PR DESCRIPTION
Adds a 2D simple shear test that includes advection along a pathline.

Also a test to check that `utils.strain_increment` is working and some minor documentation fixes.

![fig](https://github.com/seismic-anisotropy/PyDRex/assets/34595875/de9ee21b-974f-4d0d-8857-136838196a3b)
