### PR TITLE
feat: Add resolution gradient support in the mesh generator

### DIFF
--- a/examples/fluidity/advection2d/Makefile
+++ b/examples/fluidity/advection2d/Makefile
@@ -56,7 +56,7 @@ $(OUT_DIR)/$(SIM_NAME).flml: $(SRC_DIR)/$(SIM_NAME).flml
 $(OUT_DIR)/$(SIM_NAME).msh:
 	@echo "********** Building the mesh file..."
 	./envcheck.sh -m
-	pydrex-mesh -k="rectangle" -a xy $(WIDTH),$(DEPTH) $(RESOLUTION) $@
+	pydrex-mesh -k="rectangle" -a xy $(WIDTH),$(DEPTH) -r G:$(RESOLUTION) $@
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Adds simple resolution gradient functionality to the mesh generator.

CLI example:
```
pydrex-mesh -k="rectangle" -a xy 1,1 -rN:1e-2,S:1e-3 out.msh                                  [bg:1]
```

API example:
```
>>> rect = rectangle(
...     "test_rect",
...     ("x", "z"),
...     center=(0, 0),
...     width=1,
...     height=1,
...     resolution={"north-west": 1e-3, "south-east": 1e-2},
...     _write_file=False
... )
>>> rect.point_constraints[1][-1]
0.01
>>> rect.point_constraints[3][-1]
0.001
>>> rect.point_constraints[0][-1] == rect.point_constraints[2][-1]
True
>>> rect.point_constraints[0][-1]
0.0055
```

This will allow for setting a higher resolution near the ridge/corner in the initial mesh which we feed to Fluidity.