### PR TITLE
dev: Add support for Python 3.10 and test against 3.10-3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
   install-linux:
     name: (Linux) Install package and run tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - name: Checkout repository
@@ -20,7 +23,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install and test
         run: |
@@ -34,6 +37,9 @@ jobs:
   install-macos:
     name: (MacOS) Install package and run tests
     runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - name: Checkout repository
@@ -42,7 +48,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install and test
         run: |
@@ -53,6 +59,9 @@ jobs:
   install-windows:
     name: (Windows) Install package and run tests
     runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - name: Checkout repository
@@ -61,7 +70,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install and test
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ name = "pydrex"
 dynamic = ["version"]  # Managed by setuptools_scm.
 description = "Dynamic CPO calculations for olivine-enstatite polycrystal aggregates"
 readme = "README.md"
-requires-python = ">=3.11"  # We use tomllib: <https://docs.python.org/3/library/tomllib.html>.
+requires-python = ">=3.10"  # We use tomllib on 3.11: <https://docs.python.org/3/library/tomllib.html>.
 license = {file = "LICENSE"}
 authors = [
     {name = "Thomas Duvernay", email = "td75013@hotmail.fr"},
@@ -33,6 +33,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "tomli >= 1.1.0 ; python_version < '3.11'",  # https://github.com/hukkin/tomli?tab=readme-ov-file#building-a-tomlitomllib-compatibility-layer
     "numpy >= 1.8",  # <https://numpy.org/doc/stable/reference/generated/numpy.linalg.eigvalsh.html>
     "numba >= 0.57",  # <https://numba.readthedocs.io/en/stable/release-notes.html#version-0-57-0-1-may-2023>
     "scipy >= 1.2",  # <https://github.com/scipy/scipy/pull/9176>

--- a/src/pydrex/io.py
+++ b/src/pydrex/io.py
@@ -19,7 +19,13 @@ import functools as ft
 import io
 import os
 import pathlib
-import tomllib
+import sys
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
 from importlib.resources import files
 
 import h5py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 """> Configuration and fixtures for PyDRex tests."""
 
+import sys
+
 import matplotlib
 import pytest
 from _pytest.logging import LoggingPlugin, _LiveLoggingStreamHandler
@@ -140,6 +142,14 @@ def outdir(request):
 @pytest.fixture(scope="session")
 def ncpus(request):
     return max(1, request.config.getoption("--ncpus"))
+
+
+@pytest.fixture(scope="session")
+def named_tempfile_kwargs(request):
+    if sys.platform == "win32":
+        return {"delete": False}
+    else:
+        return dict()
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_scsv.py
+++ b/tests/test_scsv.py
@@ -99,7 +99,7 @@ def test_read_specfile():
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Items are not equal")
-def test_save_specfile(outdir):
+def test_save_specfile(outdir, named_tempfile_kwargs):
     """Test SCSV spec file reproduction."""
     schema = {
         "delimiter": ",",
@@ -159,8 +159,8 @@ def test_save_specfile(outdir):
         _io.save_scsv(f"{outdir}/spec_out_alt.scsv", schema_alt, data_alt)
 
     # https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile
-    temp = tempfile.NamedTemporaryFile(delete_on_close=False)
-    temp_alt = tempfile.NamedTemporaryFile(delete_on_close=False)
+    temp = tempfile.NamedTemporaryFile(**named_tempfile_kwargs)
+    temp_alt = tempfile.NamedTemporaryFile(**named_tempfile_kwargs)
     _io.save_scsv(temp.name, schema, data)
     _io.save_scsv(temp_alt.name, schema_alt, data_alt)
     raw_read = []
@@ -194,7 +194,7 @@ def test_read_Kaminski2002():
     # fmt: on
 
 
-def test_save_scsv_errors():
+def test_save_scsv_errors(named_tempfile_kwargs):
     """Check that we raise errors when attempting to write bad SCSV data."""
     schema = {
         "delimiter": ",",
@@ -208,7 +208,7 @@ def test_save_scsv_errors():
         ],
     }
     # https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile
-    temp = tempfile.NamedTemporaryFile(delete_on_close=False)
+    temp = tempfile.NamedTemporaryFile(**named_tempfile_kwargs)
     with pytest.raises(_err.SCSVError):
         foo = [1, 5, 0.2]
         _io.save_scsv(temp.name, schema, [foo])


### PR DESCRIPTION
Python > 3.10 can cause issues with Fluidity which I keep running into. Angus is on the case, but in the meantime, it wasn't much work to add support for Python 3.10 (assuming the CI behaves).