### PR TITLE
fix: Fix fl-corner2d example

### DIFF
--- a/examples/fluidity/corner2d/corner2d.flml
+++ b/examples/fluidity/corner2d/corner2d.flml
@@ -83,6 +83,17 @@
     return INITIAL_POSITIONS</string_value>
           </python>
         </initial_position>
+        <initialise_during_simulation>
+          <python>
+            <string_value type="code" language="python" lines="20">def val(t):
+    from corner2d import INITIAL_POSITIONS
+
+    if 8.7e13 &lt; t &lt; 8.75e13 or 4.3e14 &lt; t &lt; 4.4e14:
+        return INITIAL_POSITIONS
+    else:
+        return []</string_value>
+          </python>
+        </initialise_during_simulation>
         <attributes>
           <scalar_attribute_array name="CPO_">
             <dimension>


### PR DESCRIPTION
We need to spawn some particles to stop the h5part data from being cut off when particles start to exit the domain. Within the particle spawning shim, it's necessary to return an empty list (and not None) if particles should not be spawned at that particular time.