### PR TITLE
Documentation fixes/improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,31 +14,38 @@ Documentation is accessible via Python's REPL `help()` and also [online](https:/
 ## Install
 
 Check `requires-python` in `pyproject.toml` for the minimum required Python
-version. The software is tested on Linux, MacOS and Windows.
-
-The package is currently not available on PyPi, so installation requires `git`.
-Install the package with Python's `pip`:
-
-    pip install git+https://github.com/adigitoleo/PyDRex#egg=pydrex
-
-Alternatively, clone the [source code](https://github.com/seismic-anisotropy/PyDRex).
-and execute `pip install "$PWD"` in the top-level folder.
-To install additional dependencies required only for the test suite,
-use `pip install "$PWD[test]"`.
-
-For a complete development install, including documentation generator dependencies,
-use `pip install -e "$PWD[dev]"`.
-
-The package metadata and full list of dependencies are specified in [`pyproject.toml`](pyproject.toml).
+version. The software is tested on Linux, MacOS and Windows, however large
+simulations require substantial computational resources usually afforded by HPC
+Linux clusters. Linux shell scripts for setting up a [Ray](https://www.ray.io/) cluster
+on distributed memory PBS systems are provided in the `tools` folder.
 
 Optional mesh generation using [gmsh](https://pypi.org/project/gmsh/) is available,
 however the `gmsh` module requires the [`glu`](https://gitlab.freedesktop.org/mesa/glu) library
-(that may not be installed by default on all systems).
+(which may require manual installation on some systems).
+
+Tagged package versions can be installed from [PyPi](https://pypi.org/project/pydrex/).
+To install the latest version, execute:
+
+    pip install pydrex
+
+Optional dependencies can be installed using `package[dependency]` syntax, e.g.
+
+    pip install pydrex[mesh,ray]
+
+For an evolving, bleeding edge variant use the latest commit on `main`:
+
+    pip install git+https://github.com/seismic-anisotropy/PyDRex#egg=pydrex
+
+The package metadata and full list of dependencies are declared in [`pyproject.toml`](pyproject.toml).
 
 ## Test
 
 Some tests can optionally output figures or extended diagnostics when run locally.
 Check the [test suite README](tests/README.md) for details.
+
+Further examples that demonstrate how PyDRex can be used within geodynamic
+simulations are provided in the `examples` folder.
+They have their own README file as well.
 
 ## Documentation
 
@@ -49,4 +56,16 @@ with the command:
 
 which will output the html documentation into a folder called `html`.
 The homepage will be `html/index.html`.
+Note that some submodules depend on optional dependencies,
+and should otherwise be excluded:
+
+    pdoc -t docs/template -o html --math pydrex !pydrex.mesh !pydrex.distributed tests
+
 See also the provided [GitHub actions workflow](.github/workflows/docs.yml).
+
+## Contributing
+
+For a development environment, clone the [source code](https://github.com/seismic-anisotropy/PyDRex)
+and execute the Bash script `tools/venv_install.sh`.
+This will set up a local Python virtual environment with an [editable install](https://setuptools.pypa.io/en/latest/userguide/development_mode.html)
+of PyDRex that can be activated/deactivated by following the displayed prompts.

--- a/src/pydrex/diagnostics.py
+++ b/src/pydrex/diagnostics.py
@@ -40,7 +40,7 @@ def elasticity_components(voigt_matrices):
 
     Args:
     - `voigt_matrices` (array) — the Nx6x6 Voigt matrix representations of the averaged
-      elasticity tensors for a series of polycrystal textures
+      elasticity tensors for a series of N polycrystal textures
 
     Returns a dictionary with the following data series:
     - `'bulk_modulus'` — the computed bulk modulus for each Voigt matrix C
@@ -49,15 +49,15 @@ def elasticity_components(voigt_matrices):
       norm of the elastic tensor ||C|| that deviates from the norm of the "closest"
       isotropic elasticity tensor
     - `'percent_hexagonal'` — for each C, the percentage of ||C|| attributed to
-      hexagonally symmetric minerals
+      a hexagonally symmetric bulk medium
     - `'percent_tetragonal'` — for each C, the percentage of ||C|| attributed to
-      tetragonally symmetric minerals
+      tetragonally symmetric bulk medium
     - `'percent_orthorhombic'` — for each C, the percentage of ||C|| attributed to
-      orthorhombically symmetric minerals
+      orthorhombically symmetric bulk medium
     - `'percent_monoclinic'` — for each C, the percentage of ||C|| attributed to
-      monoclinically symmetric minerals
+      monoclinically symmetric bulk medium
     - `'percent_triclinic'` — for each C, the percentage of ||C|| attributed to
-      triclinically "symmetric" minerals (no mirror planes)
+      triclinically "symmetric" bulk medium (no mirror planes)
     - `'hexagonal_axis'` — for each C, the axis of hexagonal symmetry for the "closest"
       hexagonally symmetric approximation to C, a.k.a. the "transverse isotropy" axis
 

--- a/src/pydrex/diagnostics.py
+++ b/src/pydrex/diagnostics.py
@@ -51,13 +51,13 @@ def elasticity_components(voigt_matrices):
     - `'percent_hexagonal'` — for each C, the percentage of ||C|| attributed to
       a hexagonally symmetric bulk medium
     - `'percent_tetragonal'` — for each C, the percentage of ||C|| attributed to
-      tetragonally symmetric bulk medium
+      a tetragonally symmetric bulk medium
     - `'percent_orthorhombic'` — for each C, the percentage of ||C|| attributed to
-      orthorhombically symmetric bulk medium
+      an orthorhombically symmetric bulk medium
     - `'percent_monoclinic'` — for each C, the percentage of ||C|| attributed to
-      monoclinically symmetric bulk medium
+      a monoclinically symmetric bulk medium
     - `'percent_triclinic'` — for each C, the percentage of ||C|| attributed to
-      triclinically "symmetric" bulk medium (no mirror planes)
+      a triclinically "symmetric" bulk medium (no mirror planes)
     - `'hexagonal_axis'` — for each C, the axis of hexagonal symmetry for the "closest"
       hexagonally symmetric approximation to C, a.k.a. the "transverse isotropy" axis
 

--- a/tools/venv_install.sh
+++ b/tools/venv_install.sh
@@ -27,7 +27,7 @@ upgrade() {
     . .venv-"${PWD##*/}"/bin/activate
     [ -f requirements.txt ] && mv -i requirements.txt requirements.bak
     pip install --upgrade pip pip-tools && pip-compile --resolver=backtracking && pip-sync
-    pip install -e "$PWD[dev]"
+    pip install -e "${PWD}[dev,lsp,doc,test]"
 }
 
 if [ $# -eq 0 ]; then  # first install
@@ -35,12 +35,18 @@ if [ $# -eq 0 ]; then  # first install
     if [ -z "${PYTHON_BINARY:-}" ]; then
         PYTHON_BINARY="$(2>/dev/null pyenv prefix||printf '/usr')"/bin/python
     fi
-    [ $($PYTHON_BINARY --version|cut -d' ' -f2|cut -d'.' -f1) -eq 3 ] || {
+    [ "$($PYTHON_BINARY --version|cut -d' ' -f2|cut -d'.' -f1)" -eq 3 ] || {
         warn "Python 3 is required"; exit 1; }
-    [ $($PYTHON_BINARY --version|cut -d' ' -f2|cut -d'.' -f2) -gt 10 ] || {
-        warn "Python 3.11+ is required"; exit 1; }
+    [ "$($PYTHON_BINARY --version|cut -d' ' -f2|cut -d'.' -f2)" -gt 9 ] || {
+        warn "Python 3.10+ is required"; exit 1; }
     $PYTHON_BINARY -m venv .venv-"${PWD##*/}"
     upgrade
+    echo "/.venv-${PWD##*/}" >>.git/info/exclude
+    echo "/requirements.txt" >>.git/info/exclude
+    echo "/requirements.bak" >>.git/info/exclude
+    echo "$SCRIPTNAME: PyDRex development version installed in .venv-${PWD##*/}"
+    echo "$SCRIPTNAME: On Linux, execute 'source .venv-${PWD##*/}/bin/activate' to activate the environment."
+    echo "$SCRIPTNAME: Use the command 'deactivate' to subsequently deactivate the environment."
 fi
 
 while getopts "hu" OPT; do


### PR DESCRIPTION
Nothing new here, just fixing some documentation. README now suggests installing the PyPi release, elasticity tensor decomposition properly references symmetry of the medium instead of "minerals" (which reads as if it were single-crystal symmetry) and the venv install script sets up a proper dev environment with some ignore rules. First of many PRs in the next while, but I'm cutting them up to be manageable.