### PR TITLE
Add diffusion and yielding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = [
     "matplotlib",  # Plotting library, The.
     "cmcrameri",  # Matplotlib colormaps using the palettes designed by Fabio Crameri.
     "h5py",  # For reading Fluidity .h5part files.
-    "tqdm",  # For progress bars (for long-running CLI scripts)
+    "tqdm",  # For progress bars (for long-running CLI scripts).
+    "dill",  # For serializing lexical closures (i.e. passing locally-scoped functions between processors).
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ test = ["pytest"]
 doc = ["pdoc"]
 mesh = ["gmsh"]  # NOTE: Saying `import gmsh` is like saying "I don't want my CI to work".
 ray = ["ray >= 2.0.0"]
-dev = ["pdoc", "ptpython", "pyvista", "ruff", "uniplot", "pytest"]
-lsp = ["python-lsp-ruff", "python-lsp-server"]
+dev = ["pdoc", "ptpython", "pyvista", "ruff", "uniplot", "pytest", "mypy"]
+lsp = ["python-lsp-ruff", "python-lsp-server", "pylsp-mypy"]
 
 [project.urls]
 repository = "https://github.com/seismic-anisotropy/PyDRex"
@@ -94,3 +94,7 @@ exclude = [
 [tool.ruff.lint.per-file-ignores]
 "src/pydrex/__init__.py" = ["F401", "E501"]  # Don't complain about unused imports or long lines in __init__.py file.
 "tests/test_scsv.py" = ["E501"]  # Don't complain about long lines here.
+
+[[tool.mypy.overrides]]
+module = "pydrex"
+ignore_missing_imports = true

--- a/src/pydrex/__init__.py
+++ b/src/pydrex/__init__.py
@@ -139,33 +139,24 @@ from pydrex.diagnostics import (
 )
 from pydrex.geometry import (
     LatticeSystem,
-    lambert_equal_area,
     misorientation_angles,
     poles,
-    shirley_concentric_squaredisk,
     symmetry_operations,
     to_cartesian,
+    to_indices2d,
     to_spherical,
 )
-from pydrex.io import data, read_scsv, save_scsv
+from pydrex.io import data, read_scsv, save_scsv, logfile_enable
 from pydrex.minerals import (
     OLIVINE_PRIMARY_AXIS,
     OLIVINE_SLIP_SYSTEMS,
     StiffnessTensors,
     Mineral,
+    peridotite_solidus,
     voigt_averages,
 )
-from pydrex.pathlines import get_pathline
 from pydrex.stats import (
     misorientation_hist,
     misorientations_random,
     resample_orientations,
-)
-from pydrex.tensors import (
-    elastic_tensor_to_voigt,
-    rotate,
-    voigt_decompose,
-    voigt_matrix_to_vector,
-    voigt_to_elastic_tensor,
-    voigt_vector_to_matrix,
 )

--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -54,7 +54,7 @@ class DeformationRegime(IntEnum):
     The mechanism of deformation that dominates accommodation of plastic deformation
     depends in general both on material properties such as grain size and mineral phase
     content as well as on thermodynamic properties such as temperature, pressure and
-    water content (via its fugacity).
+    water fugacity.
 
     The activity of diffusive mechanisms depends more strongly on grain size, whereas
     that of dislocation mechanisms depends more strongly on temperature. High
@@ -69,6 +69,10 @@ class DeformationRegime(IntEnum):
     e.g. [Gouriet et al. 2019](http://dx.doi.org/10.1016/j.epsl.2018.10.049),
     [Garel et al. 2020](http://dx.doi.org/10.1016/j.epsl.2020.116243) and
     [Demouchy et al. 2023](http://dx.doi.org/10.2138/gselements.19.3.151).
+
+    .. note:: Although a draft texture evolution behaviour is implemented in the
+        `frictional_yielding` regime, it is experimental and not yet configurable via
+        the parameter interface.
 
     """
 

--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -49,12 +49,45 @@ class MineralPhase(IntEnum):
 
 @unique
 class DeformationRegime(IntEnum):
-    """Deformation mechanism regimes."""
+    r"""Ordinals to track distinct regimes of dominant deformation mechanisms.
 
-    diffusion = 0
-    dislocation = 1
-    byerlee = 2
-    max_viscosity = 3
+    The mechanism of deformation that dominates accommodation of plastic deformation
+    depends in general both on material properties such as grain size and mineral phase
+    content as well as on thermodynamic properties such as temperature, pressure and
+    water content (via its fugacity).
+
+    The activity of diffusive mechanisms depends more strongly on grain size, whereas
+    that of dislocation mechanisms depends more strongly on temperature. High
+    temperatures enable more frequent recovery of dislocation density equilibrium via
+    e.g. dislocation climb. Dislocation mechanisms are often accompanied by dynamic
+    recrystallisation, which acts as an additional recovery mechanism.
+
+    Rheology in the intra-granular dislocation regime was classically described by
+    separate flow laws depending on temperature; a power-law at high temperature
+    [$\dot{ε} ∝ σⁿ$] and an exponential-law at low temperature [$\dot{ε} ∝ \exp(σ)$].
+    More recent work has suggested unified dislocation creep flow laws,
+    e.g. [Gouriet et al. 2019](http://dx.doi.org/10.1016/j.epsl.2018.10.049),
+    [Garel et al. 2020](http://dx.doi.org/10.1016/j.epsl.2020.116243) and
+    [Demouchy et al. 2023](http://dx.doi.org/10.2138/gselements.19.3.151).
+
+    """
+
+    min_viscosity = 0
+    """Arbitrary lower-bound viscosity regime."""
+    matrix_diffusion = 1
+    """Intra-granular Nabarro-Herring creep, i.e. grains diffuse through the matrix."""
+    boundary_diffusion = 2
+    """Inter-granular Coble creep, i.e. grains diffuse along grain boundaries."""
+    sliding_diffusion = 3
+    """Inter-granular diffusion-assisted grain-boundary sliding (diffGBS)."""
+    matrix_dislocation = 4
+    """Intra-granular dislocation creep (glide + climb) and dynamic recrystallisation."""
+    sliding_dislocation = 5
+    """Inter-granular dislocation-assisted grain-boundary sliding (disGBS)."""
+    frictional_yielding = 6
+    """Frictional sliding along micro-fractures (Byerlee's law for yield strength)."""
+    max_viscosity = 7
+    """Arbitrary upper-bound viscosity regime."""
 
 
 @unique
@@ -197,10 +230,11 @@ def get_crss(phase, fabric):
     raise ValueError(f"phase must be a valid `MineralPhase`, not {phase}")
 
 
-# 12 args is a lot, but this way we can use numba
+# 12+ args is a lot, but this way we can use numba
 # (only primitives and numpy containers allowed).
 @nb.njit(fastmath=True)
 def derivatives(
+    regime,
     phase,
     fabric,
     n_grains,
@@ -217,6 +251,7 @@ def derivatives(
     """Get derivatives of orientation and volume distribution.
 
     Args:
+    - `regime` (`DeformationRegime`) — ordinal number of the local deformation mechanism
     - `phase` (`MineralPhase`) — ordinal number of the mineral phase
     - `fabric` (`MineralFabric`) — ordinal number of the fabric type
     - `n_grains` (int) — number of "grains" i.e. discrete volume segments
@@ -234,28 +269,57 @@ def derivatives(
     Returns a tuple with the rotation rates and grain volume fraction changes.
 
     """
-    # Based on subroutine DERIV in original Fortran.
-    strain_energies = np.empty(n_grains)
-    orientations_diff = np.empty((n_grains, 3, 3))
-    for grain_index in range(n_grains):
-        orientation_change, strain_energy = _get_rotation_and_strain(
-            phase,
-            fabric,
-            orientations[grain_index],
-            strain_rate,
-            velocity_gradient,
-            stress_exponent,
-            deformation_exponent,
-            nucleation_efficiency,
+    if regime == DeformationRegime.min_viscosity:
+        # Do absolutely nothing, all derivatives are zero.
+        return (
+            np.repeat(np.eye(3), n_grains).reshape(3, 3, n_grains).transpose(),
+            np.zeros(n_grains),
         )
-        orientations_diff[grain_index] = orientation_change
-        strain_energies[grain_index] = strain_energy
-    # Volume average mean strain energy.
-    mean_energy = np.sum(fractions * strain_energies)
-    # Strain energy residual.
-    strain_residuals = mean_energy - strain_energies
-    fractions_diff = volume_fraction * gbm_mobility * fractions * strain_residuals
-    return orientations_diff, fractions_diff
+    elif regime == DeformationRegime.matrix_diffusion:
+        # Passive rotation based on macroscopic vorticity for diffusion creep.
+        vorticity = 0.5 * (velocity_gradient - velocity_gradient.transpose())
+        # This 💃 is because numba doesn't let us use np.tile or even np.array([a] * n).
+        return (
+            np.repeat(vorticity.transpose(), n_grains)
+            .reshape(3, 3, n_grains)
+            .transpose(),
+            np.zeros(n_grains),
+        )
+    elif regime == DeformationRegime.boundary_diffusion:
+        raise ValueError("this deformation mechanism is not yet supported.")
+    elif regime == DeformationRegime.sliding_diffusion:
+        raise ValueError("this deformation mechanism is not yet supported.")
+    elif regime == DeformationRegime.matrix_dislocation:
+        # Based on subroutine DERIV in original Fortran.
+        strain_energies = np.empty(n_grains)
+        orientations_diff = np.empty((n_grains, 3, 3))
+        for grain_index in range(n_grains):
+            orientation_change, strain_energy = _get_rotation_and_strain(
+                phase,
+                fabric,
+                orientations[grain_index],
+                strain_rate,
+                velocity_gradient,
+                stress_exponent,
+                deformation_exponent,
+                nucleation_efficiency,
+            )
+            orientations_diff[grain_index] = orientation_change
+            strain_energies[grain_index] = strain_energy
+        # Volume average mean strain energy.
+        mean_energy = np.sum(fractions * strain_energies)
+        # Strain energy residual.
+        strain_residuals = mean_energy - strain_energies
+        fractions_diff = volume_fraction * gbm_mobility * fractions * strain_residuals
+        return orientations_diff, fractions_diff
+    elif regime == DeformationRegime.sliding_dislocation:
+        raise ValueError("this deformation mechanism is not yet supported.")
+    elif regime == DeformationRegime.frictional_yielding:
+        raise ValueError("this deformation mechanism is not yet supported.")
+    elif regime == DeformationRegime.max_viscosity:
+        raise ValueError("this deformation mechanism is not yet supported.")
+    else:
+        raise ValueError(f"regime must be a valid `DeformationRegime`, not {regime}")
 
 
 @nb.njit(fastmath=True)

--- a/src/pydrex/geometry.py
+++ b/src/pydrex/geometry.py
@@ -311,7 +311,7 @@ def shirley_concentric_squaredisk(xvals, yvals):
     return x_disk, y_disk
 
 
-def to_indices(horizontal, vertical):
+def to_indices2d(horizontal, vertical):
     _geometry = (horizontal.upper(), vertical.upper())
     match _geometry:
         case ("X", "Y"):

--- a/src/pydrex/io.py
+++ b/src/pydrex/io.py
@@ -179,12 +179,12 @@ def parse_scsv_schema(terse_schema):
     .. note:: This function is only defined if the version of your Python interpreter is
         greater than 3.11.x.
 
-    >>> #                   delimiter
-    >>> #                   | missing data encoding    column specifications
-    >>> #                   | |  ______________________|______________________________
-    >>> #                   v v /                                                     `
+    >>> #                delimiter
+    >>> #                | missing data encoding    column specifications
+    >>> #                | |  ______________________|______________________________
+    >>> #                v v /                                                     `
+    >>> schemastring = "d,m-:colA(s)colB(s:N/A:...)colC()colD(i:999999)colE(f:NaN:%)"
     >>> schema = parse_scsv_schema(
-    ...     "d,m-:colA(s)colB(s:N/A:...)colC()colD(i:999999)colE(f:NaN:%)"
     ... )
     >>> schema["delimiter"]
     ','

--- a/src/pydrex/io.py
+++ b/src/pydrex/io.py
@@ -184,8 +184,7 @@ def parse_scsv_schema(terse_schema):
     >>> #                | |  ______________________|______________________________
     >>> #                v v /                                                     `
     >>> schemastring = "d,m-:colA(s)colB(s:N/A:...)colC()colD(i:999999)colE(f:NaN:%)"
-    >>> schema = parse_scsv_schema(
-    ... )
+    >>> schema = parse_scsv_schema(schemastring)
     >>> schema["delimiter"]
     ','
     >>> schema["missing"]

--- a/src/pydrex/logger.py
+++ b/src/pydrex/logger.py
@@ -33,13 +33,14 @@ with handler_level("ERROR"):
 _log.info("this message will be printed to the console")
 ```
 
-To save debug logs to a file, the `logfile_enable` context manager is recommended.
+To save logs to a file, the `pydrex.io.logfile_enable` context manager is recommended.
 Always use the old printf style formatting for log messages, not fstrings,
 otherwise compute time will be wasted on string conversions when logging is disabled:
 
 ```python
+from pydrex import io as _io
 _log.quiet_aliens()  # Suppress third-party log messages except CRITICAL from Numba.
-with _log.logfile_enable("my_log_file.log"):  # Overwrite existing file unless mode="a".
+with _io.logfile_enable("my_log_file.log"):  # Overwrite existing file unless mode="a".
     value = 42
     _log.critical("critical error with value: %s", value)
     _log.error("runtime error with value: %s", value)
@@ -59,7 +60,7 @@ import sys
 
 import numpy as np
 
-from pydrex import io as _io
+# NOTE: Do NOT import any pydrex submodules here to avoid cyclical imports.
 
 np.set_printoptions(
     formatter={"float_kind": np.format_float_scientific},
@@ -131,22 +132,6 @@ def handler_level(level, handler=CONSOLE_LOGGER):
     handler.setLevel(level)
     yield
     handler.setLevel(default_level)
-
-
-@cl.contextmanager
-def logfile_enable(path, level=logging.DEBUG, mode="w"):
-    """Enable logging to a file at `path` with given `level`."""
-    logger_file = logging.FileHandler(_io.resolve_path(path), mode=mode)
-    logger_file.setFormatter(
-        logging.Formatter(
-            "%(levelname)s [%(asctime)s] %(name)s: %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-    )
-    logger_file.setLevel(level)
-    LOGGER.addHandler(logger_file)
-    yield
-    logger_file.close()
 
 
 def critical(msg, *args, **kwargs):

--- a/src/pydrex/mesh.py
+++ b/src/pydrex/mesh.py
@@ -194,7 +194,7 @@ def rectangle(name, ref_axes, center, width, height, resolution, **kwargs):
 
     """
 
-    h, v = _geo.to_indices(*ref_axes)
+    h, v = _geo.to_indices2d(*ref_axes)
     center_h, center_v = center
     point_constraints = np.zeros((4, 4))  # x, y, z, nearby_edge_length
     # TODO: Support "center" which should trigger creation of an additional

--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -194,7 +194,7 @@ class Mineral:
     >>> olA = pydrex.Mineral(
     ...     phase=pydrex.MineralPhase.olivine,
     ...     fabric=pydrex.MineralFabric.olivine_A,
-    ...     regime=pydrex.DeformationRegime.dislocation,
+    ...     regime=pydrex.DeformationRegime.matrix_dislocation,
     ...     n_grains=2000
     ... )
     >>> olA.phase
@@ -202,7 +202,7 @@ class Mineral:
     >>> olA.fabric
     <MineralFabric.olivine_A: 0>
     >>> olA.regime
-    <DeformationRegime.dislocation: 1>
+    <DeformationRegime.matrix_dislocation: 4>
     >>> olA.n_grains
     2000
 
@@ -254,7 +254,7 @@ class Mineral:
 
     phase: int = _core.MineralPhase.olivine
     fabric: int = _core.MineralFabric.olivine_A
-    regime: int = _core.DeformationRegime.dislocation
+    regime: int = _core.DeformationRegime.matrix_dislocation
     n_grains: int = _core.DefaultParams().number_of_grains
     # Initial condition, randomised if not given.
     fractions_init: np.ndarray = None
@@ -388,7 +388,7 @@ class Mineral:
         >>> olA = pydrex.Mineral(
         ...           phase=pydrex.MineralPhase.olivine,
         ...           fabric=pydrex.MineralFabric.olivine_A,
-        ...           regime=pydrex.DeformationRegime.dislocation,
+        ...           regime=pydrex.DeformationRegime.matrix_dislocation,
         ...           n_grains=pydrex.DefaultParams().number_of_grains,
         ... )
         >>> def get_velocity_gradient(t, x):  # Simple L for simple shear.
@@ -454,6 +454,7 @@ class Mineral:
             )
             # Uses nondimensional values of strain rate and velocity gradient.
             orientations_diff, fractions_diff = _core.derivatives(
+                regime=self.regime,
                 phase=self.phase,
                 fabric=self.fabric,
                 n_grains=self.n_grains,

--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -466,7 +466,7 @@ class Mineral:
                 y, self.n_grains
             )
             deformation_gradient_diff = velocity_gradient @ deformation_gradient
-            deformation_gradient_spin = _tensors.polar_decomp(
+            deformation_gradient_spin = _tensors.polar_decompose(
                 deformation_gradient_diff
             )[1]
             # Uses nondimensional values of strain rate and velocity gradient.

--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -101,6 +101,20 @@ returned by `pydrex.core.get_crss`.
 """
 
 
+def peridotite_solidus(pressure, fit="Herzberg2000"):
+    """Get peridotite solidus (i.e. melting) temperature based on experimental fits.
+
+    Pressure is expected to be in GPa.
+
+    """
+    match fit:
+        case "Herzberg2000":
+            return 1086 - 5.7 * pressure + 390 * np.log(pressure)
+        case _:
+            raise ValueError("unsupported fit")
+
+
+
 # TODO: Compare to [Man & Huang, 2011](https://doi.org/10.1007/s10659-011-9312-y).
 def voigt_averages(minerals, phase_assemblage, phase_fractions):
     """Calculate elastic tensors as the Voigt averages of a collection of `mineral`s.

--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -101,7 +101,7 @@ returned by `pydrex.core.get_crss`.
 """
 
 
-def peridotite_solidus(pressure, fit="Herzberg2000"):
+def peridotite_solidus(pressure, fit="Hirschmann2000"):
     """Get peridotite solidus (i.e. melting) temperature based on experimental fits.
 
     Pressure is expected to be in GPa.
@@ -109,7 +109,11 @@ def peridotite_solidus(pressure, fit="Herzberg2000"):
     """
     match fit:
         case "Herzberg2000":
+            # https://doi.org/10.1029/2000GC000089
             return 1086 - 5.7 * pressure + 390 * np.log(pressure)
+        case "Hirschmann2000":
+            # https://doi.org/10.1029/2000GC000070
+            return 5.104 * pressure**2 + 132.899 * pressure + 1120.661
         case _:
             raise ValueError("unsupported fit")
 

--- a/src/pydrex/tensors.py
+++ b/src/pydrex/tensors.py
@@ -12,7 +12,7 @@ import numpy as np
 
 
 @nb.njit(fastmath=True)
-def polar_decomp(matrix, left=True):
+def polar_decompose(matrix, left=True):
     """Compute polar decomposition of M as either M = RU (right) or M = VP (left)."""
     U, S, Vh = np.linalg.svd(matrix)
     if left:

--- a/src/pydrex/tensors.py
+++ b/src/pydrex/tensors.py
@@ -12,6 +12,16 @@ import numpy as np
 
 
 @nb.njit(fastmath=True)
+def polar_decomp(matrix, left=True):
+    """Compute polar decomposition of M as either M = RU (right) or M = VP (left)."""
+    U, S, Vh = np.linalg.svd(matrix)
+    if left:
+        return U @ Vh, U @ (np.diag(S) @ U.transpose())
+    U_matrix = Vh.transpose() @ (np.diag(S) @ Vh)
+    return matrix @ np.linalg.inv(U_matrix), U_matrix
+
+
+@nb.njit(fastmath=True)
 def invariants_second_order(tensor):
     """Calculate invariants of a second order tensor."""
     return (
@@ -22,7 +32,7 @@ def invariants_second_order(tensor):
         - tensor[0, 1] * tensor[1, 0]
         - tensor[1, 2] * tensor[2, 1]
         - tensor[2, 0] * tensor[0, 2],
-        np.linalg.det(tensor)
+        np.linalg.det(tensor),
     )
 
 

--- a/src/pydrex/tensors.py
+++ b/src/pydrex/tensors.py
@@ -10,13 +10,20 @@ symmetric 6x6 matrix.
 import numba as nb
 import numpy as np
 
-PERMUTATION_SYMBOL = np.array(
-    [
-        [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, -1.0, 0.0]],
-        [[0.0, 0.0, -1.0], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
-        [[0.0, 1.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-    ]
-)
+
+@nb.njit(fastmath=True)
+def invariants_second_order(tensor):
+    """Calculate invariants of a second order tensor."""
+    return (
+        np.trace(tensor),
+        tensor[0, 0] * tensor[1, 1]
+        + tensor[1, 1] * tensor[2, 2]
+        + tensor[2, 2] * tensor[0, 0]
+        - tensor[0, 1] * tensor[1, 0]
+        - tensor[1, 2] * tensor[2, 1]
+        - tensor[2, 0] * tensor[0, 2],
+        np.linalg.det(tensor)
+    )
 
 
 @nb.njit(fastmath=True)

--- a/src/pydrex/utils.py
+++ b/src/pydrex/utils.py
@@ -1,5 +1,6 @@
 """> PyDRex: Miscellaneous utility methods."""
 
+import sys
 import os
 import platform
 import subprocess
@@ -36,6 +37,12 @@ def import_proc_pool():
 
         has_ray = False
     return Pool, has_ray
+
+
+def in_ci(platform: str) -> bool:
+    """Check if we are in a GitHub runner with the given operating system."""
+    # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+    return sys.platform == platform and os.getenv("CI") is not None
 
 
 class SerializedCallable:

--- a/src/pydrex/utils.py
+++ b/src/pydrex/utils.py
@@ -66,7 +66,7 @@ class SerializedCallable:
 def serializable(f):
     """Make decorated function serializable.
 
-    .. warning:: The decorated function cannot be a method, and it will loose it's
+    .. warning:: The decorated function cannot be a method, and it will loose its
         docstring. It is not possible to use `functools.wraps` to mitigate this.
 
     """

--- a/src/pydrex/utils.py
+++ b/src/pydrex/utils.py
@@ -64,7 +64,12 @@ class SerializedCallable:
 
 
 def serializable(f):
-    """Make decorated function serializable."""
+    """Make decorated function serializable.
+
+    .. warning:: The decorated function cannot be a method, and it will loose it's
+        docstring. It is not possible to use `functools.wraps` to mitigate this.
+
+    """
     return SerializedCallable(f)
 
 

--- a/src/pydrex/utils.py
+++ b/src/pydrex/utils.py
@@ -48,6 +48,7 @@ class SerializedCallable:
         function), use the `serializable` decorator.
 
     """
+
     def __init__(self, f):
         self._f = dill.dumps(f, protocol=5, byref=True)
 
@@ -56,8 +57,27 @@ class SerializedCallable:
 
 
 def serializable(f):
-    """Make wrapped function serializable."""
+    """Make decorated function serializable."""
     return SerializedCallable(f)
+
+
+def defined_if(cond):
+    """Only define decorated function if `cond` is `True`."""
+
+    def _defined_if(f):
+        def not_f(*args, **kwargs):
+            # Throw the same as we would get from `type(undefined_symbol)`.
+            raise NameError(f"name '{f.__name__}' is not defined")
+
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            if cond:
+                return f(*args, **kwargs)
+            return not_f(*args, **kwargs)
+
+        return wrapper
+
+    return _defined_if
 
 
 @nb.njit(fastmath=True)

--- a/src/pydrex/velocity.py
+++ b/src/pydrex/velocity.py
@@ -133,7 +133,7 @@ def simple_shear_2d(direction, deformation_plane, strain_rate):
 
     """
     try:
-        indices = _geo.to_indices(direction, deformation_plane)
+        indices = _geo.to_indices2d(direction, deformation_plane)
     except ValueError:
         raise ValueError(
             "unsupported shear type with"
@@ -232,7 +232,7 @@ def cell_2d(horizontal, vertical, velocity_edge, edge_length=2):
     if edge_length < 0:
         raise ValueError(f"edge length of 2D cell must be positive, not {edge_length}")
     try:
-        indices = _geo.to_indices(horizontal, vertical)
+        indices = _geo.to_indices2d(horizontal, vertical)
     except ValueError:
         raise ValueError(
             "unsupported convection cell geometry with"
@@ -306,7 +306,7 @@ def corner_2d(horizontal, vertical, plate_speed):
 
     """
     try:
-        indices = _geo.to_indices(horizontal, vertical)
+        indices = _geo.to_indices2d(horizontal, vertical)
     except ValueError:
         raise ValueError(
             "unsupported convection cell geometry with"

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -640,7 +640,7 @@ def growth(
     return fig, ax, colors
 
 
-def figure_unless(ax):
+def figure_unless(ax: plt.Axes | None) -> tuple[plt.Figure, plt.Axes]:
     """Create figure and axes if `ax` is None, or return existing figure for `ax`.
 
     If `ax` is None, a new figure is created for the axes with a few opinionated default
@@ -649,11 +649,13 @@ def figure_unless(ax):
     Returns a tuple containing the figure handle and the axes object.
 
     """
+    fig: plt.Figure | None
     if ax is None:
         fig = plt.figure()
         ax = fig.add_subplot()
     else:
         fig = ax.get_figure()
+    assert fig is not None
     return fig, ax
 
 

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -7,6 +7,7 @@ from matplotlib import pyplot as plt
 
 from pydrex import axes as _axes
 from pydrex import core as _core
+from pydrex import geometry as _geo
 from pydrex import io as _io
 from pydrex import logger as _log
 from pydrex import utils as _utils
@@ -26,6 +27,10 @@ if "pydrex.polefigure" not in mproj.get_projection_names():
         "failed to find pydrex.polefigure projection; it should be registered in %s",
         _axes,
     )
+
+
+def default_tick_formatter(x, pos):
+    return f"{x/1e3:.1f}"
 
 
 def polefigures(
@@ -144,44 +149,41 @@ def polefigures(
     fig.savefig(_io.resolve_path(savefile))
 
 
-def pathline_box2d(
-    ax,
-    get_velocity,
-    ref_axes,
+def steady_box2d(
+    ax: plt.Axes | None,
+    velocity: tuple,
+    geometry: tuple,
+    ref_axes: str,
+    cpo: tuple | None,
     colors,
-    positions,
-    marker,
-    min_coords,
-    max_coords,
-    resolution,
     aspect="equal",
     cmap=cmc.batlow,
-    cpo_vectors=None,
-    cpo_strengths=None,
-    tick_formatter=lambda x, pos: f"{x/1e3:.1f}",
+    marker=".",
+    tick_formatter=default_tick_formatter,
+    label_suffix="(km)",
     **kwargs,
-):
-    """Plot pathlines and velocity arrows for a 2D box domain.
+) -> tuple:
+    """Plot pathlines and steady-state velocity arrows for a 2D box domain.
 
     If `ax` is None, a new figure and axes are created with `figure_unless`.
 
     Args:
-    - `get_velocity` (callable) — callable with signature f(t, x) that returns the 3D
-      velocity vector at a given time (not used) and 3D position vector
-    - `ref_axes` (two letters from {"x", "y", "z"}) — labels for the horizontal and
+    - `velocity` — tuple containing a velocity callable¹ and the 2D resolution of the
+      velocity arrow grid, e.g. [20, 20] for 20x20 arrows over the rectangular domain
+    - `geometry` — tuple containing the array of 3D pathline positions and two 2D
+      coordinates (of the lower-left and upper-right domain corners)
+    - `ref_axes` — two letters from {"x", "y", "z"} used to label the horizontal and
       vertical axes (these also define the projection for the 3D velocity/position)
-    - `colors` (array) — monotonic values along a representative pathline in the flow
-    - `positions` (Nx3 array) — 3D position vectors along the same pathline
-    - `min_coords` (array) — 2D coordinates of the lower left corner of the domain
-    - `max_coords` (array) — 2D coordinates of the upper right corner of the domain
-    - `resolution` (array) — 2D resolution of the velocity arrow grid (i.e. number of
-      grid points in the horizontal and vertical directions) which can be set to None to
-      prevent drawing velocity vectors
-    - `aspect` (str|float, optional) — see `matplotlib.axes.Axes.set_aspect`
-    - `cmap` (Matplotlib color map, optional) — color map for `colors`
-    - `cpo_vectors` (array, optional) — vectors to plot as bars at pathline locations
-    - `cpo_strengths` (array, optional) — strengths used to scale the cpo bars
-    - `tick_formatter` (callable, optional) — function used to format tick labels
+    - `cpo` — tuple containing one array of CPO strengths and one of 3D CPO vectors;
+      alternatively set this to `None` and use `marker` to only plot pathline positions
+    - `colors` — monotonic, increasing values along the pathline (e.g. time or strain)
+    - `aspect` — optional, see `matplotlib.axes.Axes.set_aspect`
+    - `cmap` — optional custom color map for `colors`
+    - `marker` — optional pathline position marker used when `cpo` is `None`
+    - `tick_formatter` — optional custom tick formatter callable
+    - `label_suffix` — optional suffix added to the axes labels
+
+    ¹with signature `f(t, x)` where `t` is not used and `x` is a 3D position vector
 
     Additional keyword arguments are passed to the `matplotlib.axes.Axes.quiver` call
     used to plot the velocity vectors.
@@ -191,11 +193,14 @@ def pathline_box2d(
 
     """
     fig, ax = figure_unless(ax)
-    ax.set_xlabel(ref_axes[0])
-    ax.set_ylabel(ref_axes[1])
+    ax.set_xlabel(f"{ref_axes[0]} {label_suffix}")
+    ax.set_ylabel(f"{ref_axes[1]} {label_suffix}")
 
+    get_velocity, resolution = velocity
+    positions, min_coords, max_coords = geometry
     x_min, y_min = min_coords
     x_max, y_max = max_coords
+
     ax.set_xlim((x_min, x_max))
     ax.set_ylim((y_min, y_max))
     ax.set_aspect(aspect)
@@ -234,21 +239,22 @@ def pathline_box2d(
             **kwargs,
         )
 
-    P = np.asarray([[p[horizontal], p[vertical]] for p in positions])
-    if cpo_vectors is not None:
-        if cpo_strengths is None:
-            cpo_strengths = np.full(len(cpo_vectors), 1.0)
-        C = np.asarray(
-            [
-                f * np.asarray([c[horizontal], c[vertical]])
-                for f, c in zip(cpo_strengths, cpo_vectors, strict=True)
-            ]
-        )
-        cpo = ax.quiver(
-            P[:, 0],
-            P[:, 1],
-            C[:, 0],
-            C[:, 1],
+    dummy_dim = ({0, 1, 2} - set(_geo.to_indices2d(*ref_axes))).pop()
+    xi_2D = np.asarray([_utils.remove_dim(p, dummy_dim) for p in positions])
+    qcoll: plt.Quiver | plt.PathCollection
+    if cpo is None:
+        qcoll = ax.scatter(xi_2D[:, 0], xi_2D[:, 1], marker=marker, c=colors, cmap=cmap)
+    else:
+        cpo_strengths, cpo_vectors = cpo
+        cpo_2D = np.asarray([
+            s * _utils.remove_dim(v, dummy_dim)
+            for s, v in zip(cpo_strengths, cpo_vectors, strict=True)
+        ])
+        qcoll = ax.quiver(
+            xi_2D[:, 0],
+            xi_2D[:, 1],
+            cpo_2D[:, 0],
+            cpo_2D[:, 1],
             colors,
             cmap=cmap,
             pivot="mid",
@@ -257,9 +263,7 @@ def pathline_box2d(
             headlength=0,
             zorder=kwargs.pop("zorder", 10) + 1,  # Always above velocity vectors.
         )
-    else:
-        cpo = ax.scatter(P[:, 0], P[:, 1], marker=marker, c=colors, cmap=cmap)
-    return fig, ax, velocities, cpo
+    return fig, ax, velocities, qcoll
 
 
 def alignment(

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -12,6 +12,8 @@ from pydrex import io as _io
 from pydrex import logger as _log
 from pydrex import utils as _utils
 
+# Use a non-interactive vector-graphics backend by default.
+plt.rcParams["backend"] = "PDF"
 # Get default figure size for easy referencing and scaling.
 DEFAULT_FIG_WIDTH, DEFAULT_FIG_HEIGHT = plt.rcParams["figure.figsize"]
 plt.rcParams["axes.grid"] = True

--- a/tests/README.md
+++ b/tests/README.md
@@ -51,7 +51,7 @@ it should accept the `outdir` positional argument,
 and check if its value is not `None`.
 If `outdir is None` then no persistent output should be produced.
 If `outdir` is a directory path (string):
-- logs can be saved by using the `pydrex.logger.logfile_enable` context manager,
+- logs can be saved by using the `pydrex.io.logfile_enable` context manager,
   which accepts a path name and an optional logging level as per Python's `logging` module
   (the default is `logging.DEBUG` which implies the most verbose output),
 - figures can be saved by (implementing and) calling a helper from `pydrex.visualisation`, and

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,10 @@
 import sys
 
 import matplotlib
+import numpy as np
 import pytest
 from _pytest.logging import LoggingPlugin, _LiveLoggingStreamHandler
+from scipy.spatial.transform import Rotation
 
 from pydrex import io as _io
 from pydrex import logger as _log
@@ -220,6 +222,20 @@ def params_Kaminski2004_fig4_circles():
 @pytest.fixture
 def params_Hedjazian2017():
     return _mock.PARAMS_HEDJAZIAN2017
+
+
+@pytest.fixture(scope="session")
+def orientations_init_y():
+    rng = np.random.default_rng(seed=8816)
+    return [
+        lambda n_grains: None,  # For random orientations.
+        lambda n_grains: Rotation.from_euler(  # A girdle around Y.
+            "y", [[x * np.pi * 2] for x in rng.random(n_grains)]
+        ).as_matrix(),
+        lambda n_grains: Rotation.from_euler(  # Clustered orientations.
+            "y", [[x * np.pi / 8] for x in rng.random(n_grains)]
+        ).as_matrix(),
+    ]
 
 
 @pytest.fixture(scope="session", params=[100, 500, 1000, 5000, 10000])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -29,7 +29,7 @@ class TestDislocationCreepOPX:
         test_id = "dudz"
         optional_logging = cl.nullcontext()
         if outdir is not None:
-            optional_logging = _log.logfile_enable(
+            optional_logging = _io.logfile_enable(
                 f"{outdir}/{SUBDIR}/{self.class_id}_{test_id}.log"
             )
         with optional_logging:
@@ -66,7 +66,7 @@ class TestDislocationCreepOPX:
         test_id = "dvdx"
         optional_logging = cl.nullcontext()
         if outdir is not None:
-            optional_logging = _log.logfile_enable(
+            optional_logging = _io.logfile_enable(
                 f"{outdir}/{SUBDIR}/{self.class_id}_{test_id}.log"
             )
         with optional_logging:
@@ -128,7 +128,7 @@ class TestDislocationCreepOlivineA:
 
         optional_logging = cl.nullcontext()
         if outdir is not None:
-            optional_logging = _log.logfile_enable(
+            optional_logging = _io.logfile_enable(
                 f"{outdir}/{SUBDIR}/{self.class_id}_{test_id}.log"
             )
             initial_angles = []
@@ -245,7 +245,7 @@ class TestDislocationCreepOlivineA:
 
         optional_logging = cl.nullcontext()
         if outdir is not None:
-            optional_logging = _log.logfile_enable(
+            optional_logging = _io.logfile_enable(
                 f"{outdir}/{SUBDIR}/{self.class_id}_{test_id}.log"
             )
             initial_angles = []
@@ -363,7 +363,7 @@ class TestDislocationCreepOlivineA:
 
         optional_logging = cl.nullcontext()
         if outdir is not None:
-            optional_logging = _log.logfile_enable(
+            optional_logging = _io.logfile_enable(
                 f"{outdir}/{SUBDIR}/{self.class_id}_{test_id}.log"
             )
             initial_angles = []
@@ -481,7 +481,7 @@ class TestDislocationCreepOlivineA:
 
         optional_logging = cl.nullcontext()
         if outdir is not None:
-            optional_logging = _log.logfile_enable(
+            optional_logging = _io.logfile_enable(
                 f"{outdir}/{SUBDIR}/{self.class_id}_{test_id}.log"
             )
             initial_angles = []
@@ -608,7 +608,7 @@ class TestRecrystallisation2D:
         cos2θ = np.cos(2 * initial_angles)
         if outdir is not None:
             out_basepath = f"{outdir}/{SUBDIR}/{self.class_id}_{test_id}"
-            optional_logging = _log.logfile_enable(f"{out_basepath}.log")
+            optional_logging = _io.logfile_enable(f"{out_basepath}.log")
 
         with optional_logging:
             initial_orientations = Rotation.from_rotvec(
@@ -705,7 +705,7 @@ class TestRecrystallisation2D:
         initial_angles = np.mgrid[0 : 2 * np.pi : 360000j]
         if outdir is not None:
             out_basepath = f"{outdir}/{SUBDIR}/{self.class_id}_{test_id}"
-            optional_logging = _log.logfile_enable(f"{out_basepath}.log")
+            optional_logging = _io.logfile_enable(f"{out_basepath}.log")
 
         with optional_logging:
             initial_orientations = Rotation.from_euler(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -44,6 +44,7 @@ class TestDislocationCreepOPX:
                     fractions=np.array([1.0]),
                     strain_rate=np.array([[0, 0, 1], [0, 0, 0], [1, 0, 0]]),
                     velocity_gradient=np.array([[0, 0, 2], [0, 0, 0], [0, 0, 0]]),
+                    deformation_gradient_spin=np.full((3, 3), np.nan),
                     stress_exponent=1.5,
                     deformation_exponent=3.5,
                     nucleation_efficiency=5,
@@ -87,6 +88,7 @@ class TestDislocationCreepOPX:
                     fractions=np.array([1.0]),
                     strain_rate=np.array([[0, 1, 0], [1, 0, 0], [0, 0, 0]]),
                     velocity_gradient=np.array([[0, 0, 0], [2, 0, 0], [0, 0, 0]]),
+                    deformation_gradient_spin=np.full((3, 3), np.nan),
                     stress_exponent=1.5,
                     deformation_exponent=3.5,
                     nucleation_efficiency=5,
@@ -173,6 +175,7 @@ class TestDislocationCreepOlivineA:
                     fractions=np.array([1.0]),
                     strain_rate=nondim_strain_rate,
                     velocity_gradient=nondim_velocity_gradient,
+                    deformation_gradient_spin=np.full((3, 3), np.nan),
                     stress_exponent=1.5,
                     deformation_exponent=3.5,
                     nucleation_efficiency=5,
@@ -289,6 +292,7 @@ class TestDislocationCreepOlivineA:
                     fractions=np.array([1.0]),
                     strain_rate=nondim_strain_rate,
                     velocity_gradient=nondim_velocity_gradient,
+                    deformation_gradient_spin=np.full((3, 3), np.nan),
                     stress_exponent=1.5,
                     deformation_exponent=3.5,
                     nucleation_efficiency=5,
@@ -406,6 +410,7 @@ class TestDislocationCreepOlivineA:
                     fractions=np.array([1.0]),
                     strain_rate=nondim_strain_rate,
                     velocity_gradient=nondim_velocity_gradient,
+                    deformation_gradient_spin=np.full((3, 3), np.nan),
                     stress_exponent=1.5,
                     deformation_exponent=3.5,
                     nucleation_efficiency=5,
@@ -523,6 +528,7 @@ class TestDislocationCreepOlivineA:
                     fractions=np.array([1.0]),
                     strain_rate=nondim_strain_rate,
                     velocity_gradient=nondim_velocity_gradient,
+                    deformation_gradient_spin=np.full((3, 3), np.nan),
                     stress_exponent=1.5,
                     deformation_exponent=3.5,
                     nucleation_efficiency=5,
@@ -609,6 +615,7 @@ class TestRecrystallisation2D:
                 [[0, 0, θ] for θ in initial_angles]
             )
             orientations_diff, fractions_diff = _core.derivatives(
+                regime=_core.DeformationRegime.matrix_dislocation,
                 phase=_core.MineralPhase.olivine,
                 fabric=_core.MineralFabric.olivine_A,
                 n_grains=360000,
@@ -616,6 +623,7 @@ class TestRecrystallisation2D:
                 fractions=np.full(360000, 1 / 360000),
                 strain_rate=np.array([[0, 1, 0], [1, 0, 0], [0, 0, 0]]),
                 velocity_gradient=np.array([[0, 0, 0], [2, 0, 0], [0, 0, 0]]),
+                deformation_gradient_spin=np.full((3, 3), np.nan),
                 stress_exponent=1.5,
                 deformation_exponent=3.5,
                 nucleation_efficiency=5,
@@ -704,6 +712,7 @@ class TestRecrystallisation2D:
                 "zx", [[np.pi / 2, θ] for θ in initial_angles]
             )
             orientations_diff, fractions_diff = _core.derivatives(
+                regime=_core.DeformationRegime.matrix_dislocation,
                 phase=_core.MineralPhase.olivine,
                 fabric=_core.MineralFabric.olivine_A,
                 n_grains=360000,
@@ -711,6 +720,7 @@ class TestRecrystallisation2D:
                 fractions=np.full(360000, 1 / 360000),
                 strain_rate=np.array([[0, 1, 0], [1, 0, 0], [0, 0, 0]]),
                 velocity_gradient=np.array([[0, 0, 0], [2, 0, 0], [0, 0, 0]]),
+                deformation_gradient_spin=np.full((3, 3), np.nan),
                 stress_exponent=1.5,
                 deformation_exponent=3.5,
                 nucleation_efficiency=5,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -36,6 +36,7 @@ class TestDislocationCreepOPX:
             for θ in np.mgrid[0 : 2 * np.pi : 360j]:
                 _log.debug("θ (°): %s", np.rad2deg(θ))
                 orientations_diff, fractions_diff = _core.derivatives(
+                    regime=_core.DeformationRegime.matrix_dislocation,
                     phase=_core.MineralPhase.enstatite,
                     fabric=_core.MineralFabric.enstatite_AB,
                     n_grains=1,
@@ -78,6 +79,7 @@ class TestDislocationCreepOPX:
                 )
                 np.testing.assert_allclose(deformation_rate.flatten(), np.zeros(9))
                 orientations_diff, fractions_diff = _core.derivatives(
+                    regime=_core.DeformationRegime.matrix_dislocation,
                     phase=_core.MineralPhase.enstatite,
                     fabric=_core.MineralFabric.enstatite_AB,
                     n_grains=1,
@@ -163,6 +165,7 @@ class TestDislocationCreepOlivineA:
                 _log.debug("deformation rate:\n%s", deformation_rate)
 
                 orientations_diff, fractions_diff = _core.derivatives(
+                    regime=_core.DeformationRegime.matrix_dislocation,
                     phase=_core.MineralPhase.olivine,
                     fabric=_core.MineralFabric.olivine_A,
                     n_grains=1,
@@ -278,6 +281,7 @@ class TestDislocationCreepOlivineA:
                 _log.debug("deformation rate:\n%s", deformation_rate)
 
                 orientations_diff, fractions_diff = _core.derivatives(
+                    regime=_core.DeformationRegime.matrix_dislocation,
                     phase=_core.MineralPhase.olivine,
                     fabric=_core.MineralFabric.olivine_A,
                     n_grains=1,
@@ -394,6 +398,7 @@ class TestDislocationCreepOlivineA:
                 _log.debug("deformation rate:\n%s", deformation_rate)
 
                 orientations_diff, fractions_diff = _core.derivatives(
+                    regime=_core.DeformationRegime.matrix_dislocation,
                     phase=_core.MineralPhase.olivine,
                     fabric=_core.MineralFabric.olivine_A,
                     n_grains=1,
@@ -510,6 +515,7 @@ class TestDislocationCreepOlivineA:
                 _log.debug("deformation rate:\n%s", deformation_rate)
 
                 orientations_diff, fractions_diff = _core.derivatives(
+                    regime=_core.DeformationRegime.matrix_dislocation,
                     phase=_core.MineralPhase.olivine,
                     fabric=_core.MineralFabric.olivine_A,
                     n_grains=1,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,7 +24,7 @@ class TestDislocationCreepOPX:
 
     class_id = "dislocation_creep_OPX"
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Not equal to tolerance")
+    @pytest.mark.skipif(_utils.in_ci("win32"), reason="Not equal to tolerance")
     def test_shear_dudz(self, outdir):
         test_id = "dudz"
         optional_logging = cl.nullcontext()
@@ -113,7 +113,7 @@ class TestDislocationCreepOlivineA:
 
     class_id = "dislocation_creep_OlA"
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Not equal to tolerance")
+    @pytest.mark.skipif(_utils.in_ci("win32"), reason="Not equal to tolerance")
     def test_shear_dvdx_slip_010_100(self, outdir):
         r"""Single grain of A-type olivine, slip on (010)[100].
 
@@ -348,7 +348,7 @@ class TestDislocationCreepOlivineA:
                 _io.resolve_path(f"{outdir}/{SUBDIR}/{self.class_id}_{test_id}.pdf")
             )
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Not equal to tolerance")
+    @pytest.mark.skipif(_utils.in_ci("win32"), reason="Not equal to tolerance")
     def test_shear_dwdx_slip_001_100(self, outdir):
         r"""Single grain of A-type olivine, slip on (001)[100].
 
@@ -466,7 +466,7 @@ class TestDislocationCreepOlivineA:
                 _io.resolve_path(f"{outdir}/{SUBDIR}/{self.class_id}_{test_id}.pdf")
             )
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Not equal to tolerance")
+    @pytest.mark.skipif(_utils.in_ci("win32"), reason="Not equal to tolerance")
     def test_shear_dvdz_slip_010_001(self, outdir):
         r"""Single grain of A-type olivine, slip on (010)[001].
 

--- a/tests/test_corner_flow_2d.py
+++ b/tests/test_corner_flow_2d.py
@@ -48,7 +48,7 @@ class TestOlivineA:
         mineral = _minerals.Mineral(
             _core.MineralPhase.olivine,
             _core.MineralFabric.olivine_A,
-            _core.DeformationRegime.dislocation,
+            _core.DeformationRegime.matrix_dislocation,
             n_grains=params["number_of_grains"],
             seed=seed,
         )

--- a/tests/test_corner_flow_2d.py
+++ b/tests/test_corner_flow_2d.py
@@ -118,7 +118,7 @@ class TestOlivineA:
         optional_logging = cl.nullcontext()
         if outdir is not None:
             out_basepath = f"{outdir}/{SUBDIR}/{self.class_id}_prescribed"
-            optional_logging = _log.logfile_enable(f"{out_basepath}.log")
+            optional_logging = _io.logfile_enable(f"{out_basepath}.log")
             npzpath = pl.Path(f"{out_basepath}.npz")
             labels = []
             angles = []

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -57,6 +57,10 @@ def test_doctests(module, capsys, verbose):
             else:
                 lineno = f":{e.test.lineno + 1 + e.example.lineno}"
             err_type, err, _ = e.exc_info
-            raise Error(
-                f"{err_type.__qualname__} encountered in {e.test.name} ({module}{lineno})"
-            ) from err
+            if err_type == NameError:  # Raised on missing optional functions.
+                # Issue warning but let the test suite pass.
+                _log.warning("skipping doctest of missing optional symbol in %s", module)
+            else:
+                raise Error(
+                    f"{err_type.__qualname__} encountered in {e.test.name} ({module}{lineno})"
+                ) from err

--- a/tests/test_scsv.py
+++ b/tests/test_scsv.py
@@ -1,6 +1,5 @@
 """> PyDRex: tests for the SCSV plain text file format."""
 
-import sys
 import tempfile
 
 import numpy as np
@@ -10,6 +9,7 @@ from numpy import testing as nt
 from pydrex import exceptions as _err
 from pydrex import io as _io
 from pydrex import logger as _log
+from pydrex import utils as _utils
 
 
 def test_validate_schema(console_handler):
@@ -98,7 +98,7 @@ def test_read_specfile():
     nt.assert_equal(data.complex_column, [0.1 + 0 * 1j, np.nan + 0 * 1j, 1.0 + 1 * 1j])
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Items are not equal")
+@pytest.mark.skipif(_utils.in_ci("win32"), reason="Items are not equal")
 def test_save_specfile(outdir, named_tempfile_kwargs):
     """Test SCSV spec file reproduction."""
     schema = {

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -252,7 +252,7 @@ class TestOlivineA:
         )
         return [cs_X0(strains), cs_X0d2(strains), cs_X0d4(strains)]
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Unable to allocate memory")
+    @pytest.mark.skipif(_utils.in_ci("win32"), reason="Unable to allocate memory")
     def test_zero_recrystallisation(self, seed):
         """Check that M*=0 is a reliable switch to turn off recrystallisation."""
         params = _core.DefaultParams().as_dict()
@@ -272,7 +272,7 @@ class TestOlivineA:
         for fractions in mineral.fractions[1:]:
             nt.assert_allclose(fractions, mineral.fractions[0], atol=1e-15, rtol=0)
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Unable to allocate memory")
+    @pytest.mark.skipif(_utils.in_ci("win32"), reason="Unable to allocate memory")
     @pytest.mark.parametrize("gbm_mobility", [50, 100, 150])
     def test_grainsize_median(self, seed, gbm_mobility):
         """Check that M*={50,100,150}, λ*=5 causes decreasing grain size median."""

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -331,7 +331,7 @@ class TestOlivineA:
         optional_logging = cl.nullcontext()
         if outdir is not None:
             out_basepath = f"{outdir}/{SUBDIR}/{self.class_id}_dvdx_ensemble_{_id}"
-            optional_logging = _log.logfile_enable(f"{out_basepath}.log")
+            optional_logging = _io.logfile_enable(f"{out_basepath}.log")
             labels = []
 
         with optional_logging:
@@ -467,7 +467,7 @@ class TestOlivineA:
         optional_logging = cl.nullcontext()
         if outdir is not None:
             out_basepath = f"{outdir}/{SUBDIR}/{self.class_id}_mobility"
-            optional_logging = _log.logfile_enable(f"{out_basepath}.log")
+            optional_logging = _io.logfile_enable(f"{out_basepath}.log")
             labels = []
 
         with optional_logging:
@@ -645,7 +645,7 @@ class TestOlivineA:
         optional_logging = cl.nullcontext()
         if outdir is not None:
             out_basepath = f"{outdir}/{SUBDIR}/{self.class_id}_calibration"
-            optional_logging = _log.logfile_enable(f"{out_basepath}.log")
+            optional_logging = _io.logfile_enable(f"{out_basepath}.log")
             labels = []
 
         with optional_logging:
@@ -792,7 +792,7 @@ class TestOlivineA:
         optional_logging = cl.nullcontext()
         if outdir is not None:
             out_basepath = f"{outdir}/{SUBDIR}/{self.class_id}_{test_id}"
-            optional_logging = _log.logfile_enable(f"{out_basepath}.log")
+            optional_logging = _io.logfile_enable(f"{out_basepath}.log")
 
         with optional_logging:
             shear_direction = Ŋ([1, 0, 0], dtype=np.float64)

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -868,17 +868,12 @@ class TestOlivineA:
             assert cpo_angles[-1] < 10
 
         if outdir is not None:
-            fig, ax, _, _ = _vis.pathline_box2d(
+            fig, ax, _, _ = _vis.steady_box2d(
                 None,
-                get_velocity,
+                (get_velocity, [20, 20]),
+                (positions, Ŋ([-2e5, -2e5]), Ŋ([2e5, 2e5])),
                 "xz",
+                (cpo_vectors, misorient_indices),
                 strains,
-                positions,
-                ".",
-                Ŋ([-2e5, -2e5]),
-                Ŋ([2e5, 2e5]),
-                [20, 20],
-                cpo_vectors=cpo_vectors,
-                cpo_strengths=misorient_indices,
             )
             fig.savefig(f"{out_basepath}.pdf")

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -135,7 +135,7 @@ class TestOlivineA:
         mineral = _minerals.Mineral(
             phase=_core.MineralPhase.olivine,
             fabric=_core.MineralFabric.olivine_A,
-            regime=_core.DeformationRegime.dislocation,
+            regime=_core.DeformationRegime.matrix_dislocation,
             n_grains=params["number_of_grains"],
             seed=seed,
         )

--- a/tests/test_simple_shear_3d.py
+++ b/tests/test_simple_shear_3d.py
@@ -153,7 +153,7 @@ class TestFraters2021:
         optional_logging = cl.nullcontext()
         if outdir is not None:
             out_basepath = f"{outdir}/{SUBDIR}/{self.class_id}_direction_change_{_id}"
-            optional_logging = _log.logfile_enable(f"{out_basepath}.log")
+            optional_logging = _io.logfile_enable(f"{out_basepath}.log")
 
         with optional_logging:
             clock_start = process_time()

--- a/tests/test_simple_shear_3d.py
+++ b/tests/test_simple_shear_3d.py
@@ -65,7 +65,7 @@ class TestFraters2021:
         olivine = _minerals.Mineral(
             phase=_core.MineralPhase.olivine,
             fabric=_core.MineralFabric.olivine_A,
-            regime=_core.DeformationRegime.dislocation,
+            regime=_core.DeformationRegime.matrix_dislocation,
             n_grains=params["number_of_grains"],
             seed=seed,
         )
@@ -73,7 +73,7 @@ class TestFraters2021:
             enstatite = _minerals.Mineral(
                 phase=_core.MineralPhase.enstatite,
                 fabric=_core.MineralFabric.enstatite_AB,
-                regime=_core.DeformationRegime.dislocation,
+                regime=_core.DeformationRegime.matrix_dislocation,
                 n_grains=params["number_of_grains"],
                 seed=seed,
             )

--- a/tests/test_vortex_2d.py
+++ b/tests/test_vortex_2d.py
@@ -437,7 +437,7 @@ class TestDiffusionCreep:
         optional_logging = cl.nullcontext()
         if outdir is not None:
             out_basepath = f"{outdir}/{SUBDIR}/{self.class_id}_olA"
-            optional_logging = _log.logfile_enable(f"{out_basepath}.log")
+            optional_logging = _io.logfile_enable(f"{out_basepath}.log")
 
         assert_each_list = [
             get_assert_each(i) for i, _ in enumerate(orientations_init_y)

--- a/tests/test_vortex_2d.py
+++ b/tests/test_vortex_2d.py
@@ -111,7 +111,7 @@ def run_singlephase(params: dict, seed: int, assert_each=None, **kwargs) -> tupl
     orientations, fractions = _stats.resample_orientations(
         mineral.orientations, mineral.fractions, seed=seed
     )
-    cpo_strengths =np.full(len(orientations), 1.0)
+    cpo_strengths = np.full(len(orientations), 1.0)
     cpo_vectors = [_diagnostics.bingham_average(o) for o in orientations]
     fig_path, ax_path, q, s = _vis.steady_box2d(
         None,
@@ -234,7 +234,7 @@ class TestCellOlivineA:
         """Run 2D cell test with 10000 grains (~14GiB RAM requirement)."""
         self.test_xz(outdir, seed, 10000)
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Unable to allocate memory")
+    @pytest.mark.skipif(_utils.in_ci("win32"), reason="Unable to allocate memory")
     @pytest.mark.parametrize("n_grains", [100, 500, 1000, 5000])
     def test_xz(self, outdir, seed, n_grains):
         """Test to check that 5000 grains is "enough" to resolve transient features."""
@@ -394,6 +394,7 @@ class TestDiffusionCreep:
 
     class_id = "diff_creep"
 
+    @pytest.mark.skipif(_utils.in_ci("win32"), reason="Unable to allocate memory")
     def test_cell_olA(self, outdir, seed, ncpus, orientations_init_y):
         params = _core.DefaultParams().as_dict()
         params["gbm_mobility"] = 10
@@ -453,5 +454,5 @@ class TestDiffusionCreep:
                     mineral, resampled_texture, fig_objects = out
                     if outdir is not None:
                         fig_objects[0].savefig(
-                                _io.resolve_path(f"{out_basepath}_path_{i}.pdf")
-                                )
+                            _io.resolve_path(f"{out_basepath}_path_{i}.pdf")
+                        )

--- a/tests/test_vortex_2d.py
+++ b/tests/test_vortex_2d.py
@@ -451,6 +451,7 @@ class TestDiffusionCreep:
                     pool.starmap(_run, zip(assert_each_list, orientations_init_list))
                 ):
                     mineral, resampled_texture, fig_objects = out
-                    fig_objects[0].savefig(
-                        _io.resolve_path(f"{out_basepath}_path_{i}.pdf")
-                    )
+                    if outdir is not None:
+                        fig_objects[0].savefig(
+                                _io.resolve_path(f"{out_basepath}_path_{i}.pdf")
+                                )

--- a/tests/test_vortex_2d.py
+++ b/tests/test_vortex_2d.py
@@ -156,16 +156,13 @@ class TestCellOlivineA:
         ]
         if outdir is not None:
             # First figure with the domain and pathline.
-            fig_path, ax_path, q, s = _vis.pathline_box2d(
+            fig_path, ax_path, q, s = _vis.steady_box2d(
                 None,
-                get_velocity,
+                (get_velocity, [20, 20]),
+                (positions, [-1, -1], [1, 1]),
                 "XZ",
+                None,
                 strains,
-                positions,
-                ".",
-                [-1, -1],
-                [1, 1],
-                [20, 20],
                 cmap="cmc.batlow_r",
                 tick_formatter=lambda x, pos: str(x),
                 aspect="equal",

--- a/tests/test_vortex_2d.py
+++ b/tests/test_vortex_2d.py
@@ -87,7 +87,7 @@ class TestCellOlivineA:
         mineral = _minerals.Mineral(
             phase=_core.MineralPhase.olivine,
             fabric=_core.MineralFabric.olivine_A,
-            regime=_core.DeformationRegime.dislocation,
+            regime=_core.DeformationRegime.matrix_dislocation,
             n_grains=params["number_of_grains"],
             seed=seed,
         )

--- a/tools/perf_compare.sh
+++ b/tools/perf_compare.sh
@@ -99,7 +99,7 @@ seed=245623452
 mineral = _minerals.Mineral(
     phase=_core.MineralPhase.olivine,
     fabric=_core.MineralFabric.olivine_A,
-    regime=_core.DeformationRegime.dislocation,
+    regime=_core.DeformationRegime.matrix_dislocation,
     n_grains=params["number_of_grains"],
     seed=seed,
 )

--- a/tools/simple_shear_2d.py
+++ b/tools/simple_shear_2d.py
@@ -20,7 +20,7 @@ seed = 245623452
 mineral = _minerals.Mineral(
     phase=_core.MineralPhase.olivine,
     fabric=_core.MineralFabric.olivine_A,
-    regime=_core.DeformationRegime.dislocation,
+    regime=_core.DeformationRegime.matrix_dislocation,
     n_grains=params["number_of_grains"],
     seed=seed,
 )


### PR DESCRIPTION
Some more rebased commits. Adds texture evolution (or lack thereof) for diffusion creep (with tests) and yielding. There are a few commented alternative ways to do diffusion creep, I'd like to leave them in as comments for now in case I come back to it.

Other things:
- simpler way to generate text file listing final particle locations
- peridotite solidus from Herzberg 2000 (with easy way to add other fits)
- get second order tensor invariants (e.g. for strain tensor)
- remove duplicated `PERMUTATION_SYMBOL` in `tensors` (it's in `core`)
- some test/visualisation improvements, requiring `dill` to allow "pickling" lexical closures
- the diffusion creep test (in `test_vortex2d`) relies on the above
- optional mypy depencency (and lsp plugin) for dev environment