### PR TITLE
dev: Bump versions of pre-commit tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,11 +28,11 @@ repos:
     -   id: mixed-line-ending
     -   id: trailing-whitespace
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
+    rev: v3.17.0
     hooks:
     -   id: pyupgrade
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.8
+    rev: v0.5.5
     hooks:
     -   id: ruff
         types_or: [ python, pyi, jupyter ]


### PR DESCRIPTION
And then we hit the big green button [over here](https://github.com/apps/pre-commit-ci) again.