### PR TITLE
docs: Fix 404s from PyPI landing page and update metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `pydrex.viscosity` module with effective viscosity contributions for
+  different deformation mechanisms based on a selection of proposed
+  constitutive equations
+- Option to use Herzberg et al. 2000 peridotite solidus fit
+- Decorator to serialize lexical closures using `dill`
 - `pydrex.update_all` to update texture of multiphase aggregates simultaneously
 - `get_regime` argument to `update_all`/`update_orientations` to allow for
   temporally variable deformation regimes
@@ -22,9 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Symbol names for default stiffness tensors (now members of
   `minerals.StiffnessTensors` — use your own preferred stiffness tensors by
   passing a custom instance when e.g. calculating Voigt averages)
+- Default parameter namespace (moved from `io.DEFAULT_PARAMS` to
+  `core.DefaultParams`)
 
 ### Fixed
 - Handling of enstatite in Voigt averaging
+- Handling of optional keyword args in some visualisation functions
 
 
 ## [0.0.1] - 2024-04-24

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.SHELLFLAGS += -u
+.ONESHELL:
+MAKEFLAGS += --no-builtin-rules
+
+dist:
+	python -m build
+
+release: dist
+	python -m twine upload dist/*
+
+test:
+	mkdir out
+	pytest -v --outdir=out
+
+clean:
+	rm -r dist
+	rm -r out
+
+.PHONY: release test clean

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 
 This repository contains a Python 3 reimplementation of the D-Rex model
 for the evolution of crystallographic preferred orientation in polycrystals.
-The code is available for use under the [GNU GPL v3](LICENSE) license.
+The code is available for use under the [GNU GPL v3](https://www.gnu.org/licenses/gpl-3.0.en.html) license.
 Documentation is accessible via Python's REPL `help()` and also [online](https://seismic-anisotropy.github.io/PyDRex/).
 
-## Install
+## Installing
 
 Check `requires-python` in `pyproject.toml` for the minimum required Python
 version. The software is tested on Linux, MacOS and Windows, however large
@@ -36,18 +36,25 @@ For an evolving, bleeding edge variant use the latest commit on `main`:
 
     pip install git+https://github.com/seismic-anisotropy/PyDRex#egg=pydrex
 
-The package metadata and full list of dependencies are declared in [`pyproject.toml`](pyproject.toml).
+However, note that pip does not know how to uninstall dependencies of pacakges.
+Versioned source distributions, which include tests and examples, are also
+available from the [PyPI downloads page](https://pypi.org/project/pydrex/#files).
+These include package metadata and a full list of dependencies
+declared in the `pyproject.toml` file.
 
-## Test
+## Testing
+
+Running tests or examples requires a local git clone or unpacked source distribution.
 
 Some tests can optionally output figures or extended diagnostics when run locally.
-Check the [test suite README](tests/README.md) for details.
+Testing locally requires a local git clone or source distribution of PyDRex.
+Check the `tests/README.md` file for details.
 
 Further examples that demonstrate how PyDRex can be used within geodynamic
 simulations are provided in the `examples` folder.
 They have their own README file as well.
 
-## Documentation
+## Building offline documentation
 
 The documentation can be built offline using [pdoc](https://github.com/mitmproxy/pdoc),
 with the command:
@@ -61,7 +68,7 @@ and should otherwise be excluded:
 
     pdoc -t docs/template -o html --math pydrex !pydrex.mesh !pydrex.distributed tests
 
-See also the provided [GitHub actions workflow](.github/workflows/docs.yml).
+See also the provided [GitHub actions workflow](https://raw.githubusercontent.com/seismic-anisotropy/PyDRex/main/.github/workflows/docs.yml).
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,9 @@ authors = [
     {name = "Chris Mathews"},
 ]
 keywords = ["CPO", "LPO", "olivine", "deformation", "anisotropy", "crystallography"]
-classifiers = [
+classifiers = [  # List of possible classifiers: <https://pypi.org/classifiers/>.
     "Programming Language :: Python :: 3",
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 3 - Alpha",
     "Topic :: Scientific/Engineering :: Physics",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
@@ -46,17 +46,33 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest"]
-doc = ["pdoc"]
-mesh = ["gmsh"]  # NOTE: Saying `import gmsh` is like saying "I don't want my CI to work".
-ray = ["ray >= 2.0.0"]
-dev = ["pdoc", "pre-commit", "ptpython", "pyvista", "ruff", "uniplot", "pytest", "mypy"]
-lsp = ["python-lsp-ruff", "python-lsp-server", "pylsp-mypy"]
+# These optional dependencies are relevant for built distributions (e.g. via pip):
+mesh = ["gmsh"]  # Required for pydrex-mesh, doesn't play nice with CI.
+ray = ["ray >= 2.0.0"]  # Required for distributed-memory examples.
+# These optional dependencies are only relevant for source distributions:
+test = ["pytest"]  # Minimal test dependencies, for CI.
+doc = ["pdoc"]  # Minimal html docs dependencies, for CI.
+dev = [  # Full developer dependencies, including packaging and visualisation tools.
+    "build",
+    "mypy",
+    "pdoc",
+    "pre-commit",
+    "ptpython",
+    "pytest",
+    "pyvista",
+    "ruff",
+    "twine",
+    "uniplot",
+]
+# Language server protocol support for modern editors/linters.
+lsp = ["python-lsp-ruff", "python-lsp-server", "pylsp-mypy", "fortls"]
 
+# Metadata for PyPI landing page.
 [project.urls]
 repository = "https://github.com/seismic-anisotropy/PyDRex"
 documentation = "https://seismic-anisotropy.github.io/PyDRex/"
 
+# CLI entry points.
 [project.scripts]
 pydrex-polefigures = "pydrex.cli:CLI_HANDLERS.pole_figure_visualiser"
 pydrex-mesh = "pydrex.cli:CLI_HANDLERS.mesh_generator"
@@ -64,13 +80,15 @@ pydrex-h5party="pydrex.cli:CLI_HANDLERS.h5part_extractor"
 npzshow = "pydrex.cli:CLI_HANDLERS.npz_file_inspector"
 
 # Make setuptools include datafiles in wheels/packages.
-# Data files must be inside the package directory.
+# Data files must be inside the src/<package> directory.
 [tool.setuptools]
 include-package-data = true
 
-# Use src/<package> layout to keep things clean.
 [tool.setuptools.packages.find]
+# Use src/<package> layout to keep things clean.
 where = ["src"]
+# Special exclude rules for the wheel, NOTE: Use foo* glob instead of foo/*.
+exclude = ["initial_implementation*"]
 
 # Some global pytest configuration settings, avoids having an extra pytest.ini file.
 [tool.pytest.ini_options]
@@ -95,6 +113,7 @@ exclude = [
 "src/pydrex/__init__.py" = ["F401", "E501"]  # Don't complain about unused imports or long lines in __init__.py file.
 "tests/test_scsv.py" = ["E501"]  # Don't complain about long lines here.
 
+# Silence mypy noise about packages that don't have type hints/stubs.
 [[tool.mypy.overrides]]
 module = "pydrex.*,numba.*,h5py.*,meshio.*,gmsh.*,dill.*,cmcrameri.*,scipy.*,ray.*"
 ignore_missing_imports = true


### PR DESCRIPTION
- Avoid relative links in README.md, because they don't work in PyPI (only archives are copied there, not the whole tree)
- Update CHANGELOG to include everything notable since 0.0.1 so far
- Exclude `src/initial_implementation` from built distribution (wheel)
- Add Makefile with build and release goals to aid in maintenance