### PR TITLE
Fix logging/pytest setup and make mock objects subclasses of `DefaultParams`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to toggle verbose doctest output using `pytest -vv`
 
 ### Changed
+- Symbol name of `pydrex.logger.handler_level` to `pydrex.io.log_cli_level`
 - Call signature for steady flow 2D box visualisation function
 - Symbol names for default stiffness tensors (now members of
   `minerals.StiffnessTensors` — use your own preferred stiffness tensors by
@@ -34,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handling of enstatite in Voigt averaging
 - Handling of optional keyword args in some visualisation functions
 
+### Removed
+- Access to `io` symbols in global `pydrex` namespace (use `pydrex.io` instead)
 
 ## [0.0.1] - 2024-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to toggle verbose doctest output using `pytest -vv`
 
 ### Changed
+- `mock` objects to be subclasses of `core.DefaultParams` with new symbol names
 - Symbol name of `pydrex.logger.handler_level` to `pydrex.io.log_cli_level`
 - Call signature for steady flow 2D box visualisation function
 - Symbol names for default stiffness tensors (now members of

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .SHELLFLAGS += -u
 .ONESHELL:
 MAKEFLAGS += --no-builtin-rules
-VERSION = $(shell git describe)
+VERSION = $(shell python -m setuptools_scm -f plain)
 
 # NOTE: Keep this at the top! Bare `make` should just build the sdist + bdist.
 dist:
@@ -14,15 +14,21 @@ test:
 	mkdir out
 	pytest -v --outdir=out
 
+# WARNING: --math fetches .js code from a CDN, be careful where it comes from:
+# https://github.com/mitmproxy/pdoc/security/advisories/GHSA-5vgj-ggm4-fg62
 html:
 	2>pdoc.log pdoc -t docs/template -o html pydrex !pydrex.mesh !pydrex.distributed tests \
 		--favicon "https://raw.githubusercontent.com/seismic-anisotropy/PyDRex/main/docs/assets/favicon32.png" \
-		--footer-text "PyDRex $(VERSION)"
+		--footer-text "PyDRex $(VERSION)" \
+		--math
 
+# WARNING: --math fetches .js code from a CDN, be careful where it comes from:
+# https://github.com/mitmproxy/pdoc/security/advisories/GHSA-5vgj-ggm4-fg62
 live_docs:
 	pdoc -t docs/template pydrex !pydrex.mesh !pydrex.distributed tests \
 		--favicon "https://raw.githubusercontent.com/seismic-anisotropy/PyDRex/main/docs/assets/favicon32.png" \
-		--footer-text "PyDRex $(VERSION)"
+		--footer-text "PyDRex $(VERSION)" \
+		--math
 
 clean:
 	rm -rf dist

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,15 @@ html:
 		--favicon "https://raw.githubusercontent.com/seismic-anisotropy/PyDRex/main/docs/assets/favicon32.png" \
 		--footer-text "PyDRex $(VERSION)"
 
+live_docs:
+	pdoc -t docs/template pydrex !pydrex.mesh !pydrex.distributed tests \
+		--favicon "https://raw.githubusercontent.com/seismic-anisotropy/PyDRex/main/docs/assets/favicon32.png" \
+		--footer-text "PyDRex $(VERSION)"
+
 clean:
 	rm -rf dist
 	rm -rf out
 	rm -rf html
 	rm -rf pdoc.log
 
-.PHONY: release test clean
+.PHONY: release test live_docs clean

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ Install documentation builder dependencies with `pip install '.[doc]'`.
 Run `make html` from the terminal to generate PyDRex's documentation
 (available in the `html` directory), including the API reference.
 The homepage will be `html/index.html`.
+Alternatively, run `make live_docs` to build and serve the documentation on a `localhost` port.
+Follow the displayed prompts to open the live documentation in a browser.
+It should automatically reload after changes to the source code.
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,13 +92,15 @@ exclude = ["initial_implementation*"]
 
 # Some global pytest configuration settings, avoids having an extra pytest.ini file.
 [tool.pytest.ini_options]
-# NOTE: Do NOT use pytest log_cli option, see tests/conftest for logging setup.
 # Only look in '.tests/`, don't search git subprojects/worktrees or anything like that,
 # <https://github.com/pytest-dev/pytest/issues/10298>.
 testpaths = ["tests"]
 # --tb=short : Use short tracebacks, terminal scrollback is precious.
-# --show-capture=no : Don't show captured output (stdout/stderr/logs) for failed tests.
-addopts = "--tb=short --show-capture=no"
+# --capture=fd : Capture sys.std{out,err} and file descriptors 1 and 2 by default, show if -v is given.
+# --show-capture=no : Don't show captured output for failed tests, use -v instead.
+# -p no:logging : Disable built-in logging plugin, we have our own.
+addopts = "--tb=short --capture=fd --show-capture=no -p no:logging"
+# NOTE: We do not respect the log_cli=true option. Use pytest -v to get live logs instead.
 
 # Global linter and devtools settings.
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ testpaths = ["tests"]
 # --show-capture=no : Don't show captured output for failed tests, use -v instead.
 # -p no:logging : Disable built-in logging plugin, we have our own.
 addopts = "--tb=short --capture=fd --show-capture=no -p no:logging"
-# NOTE: We do not respect the log_cli=true option. Use pytest -v to get live logs instead.
 
 # Global linter and devtools settings.
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ mesh = ["gmsh"]  # Required for pydrex-mesh, doesn't play nice with CI.
 ray = ["ray >= 2.0.0"]  # Required for distributed-memory examples.
 # These optional dependencies are only relevant for source distributions:
 test = ["pytest"]  # Minimal test dependencies, for CI.
-doc = ["pdoc"]  # Minimal html docs dependencies, for CI.
+doc = ["pdoc", "setuptools-scm"]  # Minimal html docs dependencies, for CI.
 dev = [  # Full developer dependencies, including packaging and visualisation tools.
     "build",
     "mypy",
@@ -61,6 +61,7 @@ dev = [  # Full developer dependencies, including packaging and visualisation to
     "pytest",
     "pyvista",
     "ruff",
+    "setuptools-scm",
     "twine",
     "uniplot",
 ]

--- a/src/pydrex/__init__.py
+++ b/src/pydrex/__init__.py
@@ -146,7 +146,6 @@ from pydrex.geometry import (
     to_indices2d,
     to_spherical,
 )
-from pydrex.io import data, logfile_enable, read_scsv, save_scsv
 from pydrex.minerals import (
     OLIVINE_PRIMARY_AXIS,
     OLIVINE_SLIP_SYSTEMS,

--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -120,6 +120,7 @@ class DeformationRegime(IntEnum):
 
 # Because frozen=True doesn't guarantee recursive immutabillity,
 # check hashability in a doctest to ensure that this is actually immutable.
+# This also ensures that subclasses are immutable (see pydrex.mock).
 # Remember to use tuples instead of lists for members.
 @dataclass(frozen=True)
 class DefaultParams:

--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -136,6 +136,7 @@ class DefaultParams:
     False
 
     """
+
     phase_assemblage: tuple = (MineralPhase.olivine,)
     """Mineral phases present in the aggregate."""
     phase_fractions: tuple = (1.0,)
@@ -290,6 +291,15 @@ class DefaultParams:
     used the ERF variant with: [4.4e8, -2.2e4, 3e-2, 1.3e-4, -42, 4.2e-2, -1.1e-5].
 
     """
+
+    @classmethod
+    def __check_type__(cls, field, value):
+        if not isinstance(value, type(getattr(cls, field))):
+            raise ValueError(f"Illegal type for {cls.__qualname__}.{field}")
+
+    def __post_init__(self):
+        for k, v in self.__dict__.items():
+            self.__check_type__(k, v)
 
     def as_dict(self):
         """Return mutable copy of default arguments as a dictionary."""

--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -129,10 +129,11 @@ class DefaultParams:
     Use `as_dict` to get a mutable copy.
 
     >>> defaults = DefaultParams()
-    >>> from collections.abc import Hashable
-    >>> isinstance(defaults, Hashable)  # supports hash()
+    >>> # Evaluating hash() will raise an error if the argument is mutable.
+    >>> isinstance(hash(defaults), int)
     True
-    >>> isinstance(defaults.as_dict(), Hashable)
+    >>> from collections.abc import Hashable
+    >>> isinstance(defaults.as_dict(), Hashable)  # No longer supports hash().
     False
 
     """

--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -294,7 +294,7 @@ class DefaultParams:
 
     def __post_init__(self):
         for k, v in self.__dataclass_fields__.items():
-            if v.type is not type(v.default_value):
+            if v.type is not type(v.default):
                 raise ValueError(f"Illegal type for {self.__class__.__qualname__}.{k}")
 
     def as_dict(self):

--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -292,17 +292,22 @@ class DefaultParams:
 
     """
 
-    @classmethod
-    def __check_type__(cls, field, value):
-        if not isinstance(value, type(getattr(cls, field))):
-            raise ValueError(f"Illegal type for {cls.__qualname__}.{field}")
-
     def __post_init__(self):
-        for k, v in self.__dict__.items():
-            self.__check_type__(k, v)
+        for k, v in self.__dataclass_fields__.items():
+            if v.type is not type(v.default_value):
+                raise ValueError(f"Illegal type for {self.__class__.__qualname__}.{k}")
 
     def as_dict(self):
-        """Return mutable copy of default arguments as a dictionary."""
+        """Return mutable copy of default arguments as a dictionary.
+
+        The reverse operation is achieved simply by passing the dictionary
+        back into the class constructor:
+
+        >>> params_mutable = DefaultParams().as_dict()
+        >>> params_mutable["number_of_grains"] = 9999
+        >>> params_immutable = DefaultParams(**params_mutable)
+
+        """
         return asdict(self)
 
 

--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -202,7 +202,7 @@ class DefaultParams:
     but that is not yet implemented.
 
     """
-    disl_Peierls_stress: float = 2
+    disl_Peierls_stress: float = 2.0
     """Stress barrier in GPa for activation of dislocation motion at low temperatures.
 
     - 2GPa suggested by [Demouchy et al. 2023](http://dx.doi.org/10.2138/gselements.19.3.151)

--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -118,8 +118,23 @@ class DeformationRegime(IntEnum):
     """Arbitrary upper-bound viscosity regime."""
 
 
+# Because frozen=True doesn't guarantee recursive immutabillity,
+# check hashability in a doctest to ensure that this is actually immutable.
+# Remember to use tuples instead of lists for members.
 @dataclass(frozen=True)
 class DefaultParams:
+    """Immutable record of default parameters for PyDRex.
+
+    Use `as_dict` to get a mutable copy.
+
+    >>> defaults = DefaultParams()
+    >>> from collections.abc import Hashable
+    >>> isinstance(defaults, Hashable)  # supports hash()
+    True
+    >>> isinstance(defaults.as_dict(), Hashable)
+    False
+
+    """
     phase_assemblage: tuple = (MineralPhase.olivine,)
     """Mineral phases present in the aggregate."""
     phase_fractions: tuple = (1.0,)

--- a/src/pydrex/io.py
+++ b/src/pydrex/io.py
@@ -783,12 +783,13 @@ def logfile_enable(path, level: str | int = logging.DEBUG, mode="w"):
     # Path can be an io.TextIOWrapper or io.StringIO, for testing purposes.
     logger_file: logging.StreamHandler | logging.FileHandler
     if isinstance(path, (io.StringIO, io.TextIOWrapper)):
+        _log.debug("enabling logging at %s level to IO stream")
         logger_file = logging.StreamHandler(path)
         logger_file.setFormatter(formatter)
         logger_file.setLevel(level)
         _log.LOGGER.addHandler(logger_file)
     else:
-        _log.critical("%s", type(path))
+        _log.debug("enabling logging at %s level to %s", level, path)
         logger_file = logging.FileHandler(resolve_path(path), mode=mode)
         logger_file.setFormatter(formatter)
         logger_file.setLevel(level)

--- a/src/pydrex/logger.py
+++ b/src/pydrex/logger.py
@@ -57,7 +57,8 @@ In these examples, (open) temporary files and streams are used for demonstration
 
 >>> import tempfile
 >>> import io
->>> tmp = tempfile.NamedTemporaryFile()
+>>> kwargs = { "delete_on_close": False } if sys.platform == "win32" else {}
+>>> tmp = tempfile.NamedTemporaryFile(**kwargs)
 >>> pydrex_logger.debug("debug message")
 >>> with pydrex.io.logfile_enable(io.TextIOWrapper(tmp.file)):  # doctest: +ELLIPSIS
 ...     pydrex_logger.debug("debug message in %s", tmp.file.name)

--- a/src/pydrex/logger.py
+++ b/src/pydrex/logger.py
@@ -57,7 +57,7 @@ In this example, (open) temporary files and streams are used for demonstration.
 
 >>> import tempfile
 >>> import io
->>> kwargs = { "delete_on_close": False } if sys.platform == "win32" else {}
+>>> kwargs = { "delete": False } if sys.platform == "win32" else {}
 >>> tmp = tempfile.NamedTemporaryFile(**kwargs)
 >>> pydrex_logger.debug("debug message")
 >>> with pydrex.io.logfile_enable(io.TextIOWrapper(tmp.file)):  # doctest: +ELLIPSIS

--- a/src/pydrex/logger.py
+++ b/src/pydrex/logger.py
@@ -53,7 +53,7 @@ True
 False
 
 Usually, a filename should be given to the `pydrex.io.logfile_enable` context manager.
-In these examples, (open) temporary files and streams are used for demonstration.
+In this example, (open) temporary files and streams are used for demonstration.
 
 >>> import tempfile
 >>> import io
@@ -65,14 +65,6 @@ In these examples, (open) temporary files and streams are used for demonstration
 ...     with open(tmp.file.name) as f:
 ...         print(f.readline())
 DEBUG [...] pydrex: debug message ...
-
->>> _ = cli_handler.setStream(sys.stderr)  # Doctests don't check stderr.
->>> pydrex_logger.info("info message")
->>> with pydrex.io.logfile_enable(sys.stdout):  # doctest: +ELLIPSIS
-...     pydrex_logger.debug("debug message to stdout")
-...     pydrex_logger.info("info message to stdout")
-DEBUG [...] pydrex: debug message to stdout
-INFO [...] pydrex: info message to stdout
 
 ### Information for PyDRex developers
 

--- a/src/pydrex/logger.py
+++ b/src/pydrex/logger.py
@@ -1,59 +1,87 @@
 """> PyDRex: logger settings and boilerplate.
 
-Python's logging module is weird and its methods don't allow us to specify
-which logger to use, so just using `logging.debug` for example always uses
-the "root" logger, which spams a bunch of messages from other imports/modules.
-Instead, the methods in this module are thin wrappers that use custom
-logging objects (`pydrex.logger.LOGGER` and `pydrex.logger.CONSOLE_LOGGER`).
-The method `quiet_aliens` can be invoked to suppress most messages
-from third-party modules, except critical errors and warnings from Numba.
+.. note:: Always use the old printf style formatting for log messages, not fstrings,
+    otherwise compute time may be wasted on string conversions when logging is disabled:
 
-By default, PyDRex emits INFO level messages to the console.
-This can be changed globally by setting the new level with `CONSOLE_LOGGER.setLevel`:
+The methods in this module are thin `logging` wrappers that use custom logger objects
+(`pydrex.logger.LOGGER` and its `StreamHandler`, `pydrex.logger.CONSOLE_LOGGER`).
+For packages that depend on PyDRex, the `pydrex.logger.LOGGER` should be accessed by:
 
-```python
-from pydrex import logger as _log
-_log.info("this message will be printed to the console")
+>>> import logging
+>>> import pydrex
+>>> pydrex_logger = logging.getLogger("pydrex")
 
-_log.CONSOLE_LOGGER.setLevel("ERROR")
-_log.info("this message will NOT be printed to the console")
-_log.error("this message will be printed to the console")
-```
+Console logs are written at `INFO` level to `sys.stderr` by default:
 
-To change the console logging level for a particular local context,
-use the `handler_level` context manager:
+>>> # ELLIPSIS is <stderr> except in test session.
+>>> pydrex_logger.handlers  # doctest: +ELLIPSIS
+[<StreamHandler ... (INFO)>]
 
-```python
-_log.CONSOLE_LOGGER.setLevel("INFO")
-_log.info("this message will be printed to the console")
+The following examples use `sys.stdout` instead (`...` represents a timestamp).
 
-with handler_level("ERROR"):
-    _log.info("this message will NOT be printed to the console")
+>>> import sys
+>>> cli_handler = pydrex_logger.handlers[0]
+>>> _ = cli_handler.setStream(sys.stdout)  # Doctests don't check stderr.
+>>> cli_handler.formatter.color_enabled = False  # Disable colors in output.
+>>> pydrex_logger.info("info message")  # doctest: +ELLIPSIS
+INFO [...] pydrex: info message
+>>> cli_handler.setLevel(logging.ERROR)
+>>> pydrex_logger.info("info message")
+>>> pydrex_logger.error("error message")  # doctest: +ELLIPSIS
+ERROR [...] pydrex: error message
 
-_log.info("this message will be printed to the console")
-```
+This change persists across successive requests for logger object access:
 
-To save logs to a file, the `pydrex.io.logfile_enable` context manager is recommended.
-Always use the old printf style formatting for log messages, not fstrings,
-otherwise compute time will be wasted on string conversions when logging is disabled:
+>>> pydrex_logger = logging.getLogger("pydrex")
+>>> cli_handler.level == logging.INFO
+False
+>>> cli_handler.level == logging.ERROR
+True
 
-```python
-from pydrex import io as _io
-_log.quiet_aliens()  # Suppress third-party log messages except CRITICAL from Numba.
-with _io.logfile_enable("my_log_file.log"):  # Overwrite existing file unless mode="a".
-    value = 42
-    _log.critical("critical error with value: %s", value)
-    _log.error("runtime error with value: %s", value)
-    _log.warning("warning with value: %s", value)
-    _log.info("information message with value: %s", value)
-    _log.debug("verbose debugging message with value: %s", value)
-    ... # Construct Minerals, update orientations, etc.
+### Log files and logging contexts
 
-```
+The logging level can also be adjusted using context managers,
+both for console output and (optionally) saving logs to a file:
+
+>>> cli_handler.setLevel(logging.INFO)
+>>> cli_handler.level == logging.DEBUG
+False
+>>> with pydrex.io.log_cli_level(logging.DEBUG, cli_handler):
+...     cli_handler.level == logging.DEBUG
+True
+>>> cli_handler.level == logging.DEBUG
+False
+
+Usually, a filename should be given to the `pydrex.io.logfile_enable` context manager.
+In these examples, (open) temporary files and streams are used for demonstration.
+
+>>> import tempfile
+>>> import io
+>>> tmp = tempfile.NamedTemporaryFile()
+>>> pydrex_logger.debug("debug message")
+>>> with pydrex.io.logfile_enable(io.TextIOWrapper(tmp.file)):  # doctest: +ELLIPSIS
+...     pydrex_logger.debug("debug message in %s", tmp.file.name)
+...     with open(tmp.file.name) as f:
+...         print(f.readline())
+DEBUG [...] pydrex: debug message ...
+
+>>> _ = cli_handler.setStream(sys.stderr)  # Doctests don't check stderr.
+>>> pydrex_logger.info("info message")
+>>> with pydrex.io.logfile_enable(sys.stdout):  # doctest: +ELLIPSIS
+...     pydrex_logger.debug("debug message to stdout")
+...     pydrex_logger.info("info message to stdout")
+DEBUG [...] pydrex: debug message to stdout
+INFO [...] pydrex: info message to stdout
+
+### Information for PyDRex developers
+
+All PyDRex modules that require logging should use `import pydrex.logger`,
+which automatically initialises and registers the PyDRex logger objects if necessary.
+
+The method `quiet_aliens` can be invoked to suppress logging messages from dependencies.
 
 """
 
-import contextlib as cl
 import functools as ft
 import logging
 import sys
@@ -75,6 +103,10 @@ class ConsoleFormatter(logging.Formatter):
     """Log formatter that uses terminal color codes."""
 
     def colorfmt(self, code):
+        # Color enabled by default, disabled by setting `.color_enabled` = False.
+        # Adding this as a constructor arg breaks things...
+        if hasattr(self, "color_enabled") and not self.color_enabled:
+            return "%(levelname)s [%(asctime)s] %(name)s: %(message)s"
         return (
             f"\033[{code}m%(levelname)s [%(asctime)s]\033[m"
             + " \033[1m%(name)s:\033[m %(message)s"
@@ -119,22 +151,6 @@ def handle_exception(exec_type, exec_value, exec_traceback):
 sys.excepthook = handle_exception
 
 
-@cl.contextmanager
-def handler_level(level: str, handler: logging.Handler = CONSOLE_LOGGER):
-    """Set logging handler level for current context.
-
-    - `level` — logging level name e.g. "DEBUG", "ERROR", etc. See Python's logging
-      module for details.
-    - `handler` (optional) — alternative handler to control instead of the default,
-      `CONSOLE_LOGGER`.
-
-    """
-    default_level = handler.level
-    handler.setLevel(level)
-    yield
-    handler.setLevel(default_level)
-
-
 def critical(msg, *args, **kwargs):
     """Log a CRITICAL message in PyDRex."""
     LOGGER.critical(msg, *args, **kwargs)
@@ -169,13 +185,16 @@ def exception(msg, *args, **kwargs):
     LOGGER.exception(msg, *args, **kwargs)
 
 
-def quiet_aliens():
-    """Restrict alien loggers 👽 because I'm trying to find MY bugs, thanks."""
-    # Only allow warnings or above from root logger.
-    logging.getLogger().setLevel(logging.WARNING)
-    # Only allow critical stuff from other things.
+def quiet_aliens(root_level=logging.WARNING, level=logging.CRITICAL):
+    """Restrict alien loggers 👽.
+
+    .. note:: Primarily intended for internal use (test suite/development).
+
+    - `root_level` sets the level for the "root" logger
+    - `level` sets the level for everything else (except "pydrex")
+
+    """
+    logging.getLogger().setLevel(root_level)
     for name in logging.Logger.manager.loggerDict.keys():
         if name != "pydrex":
-            logging.getLogger(name).setLevel(logging.CRITICAL)
-    # Numba is not in the list for some reason, I guess we can leave warnings.
-    logging.getLogger("numba").setLevel(logging.WARNING)
+            logging.getLogger(name).setLevel(level)

--- a/src/pydrex/mesh.py
+++ b/src/pydrex/mesh.py
@@ -51,6 +51,15 @@ class Model:
     _write_file: bool = True
     _was_entered: bool = False
 
+    @classmethod
+    def __check_type__(cls, field, value):
+        if not isinstance(value, type(getattr(cls, field))):
+            raise ValueError(f"Illegal type for {cls.__qualname__}.{field}")
+
+    def __post_init__(self):
+        for k, v in self.__dict__.items():
+            self.__check_type__(k, v)
+
     # TODO: Possible attributes worth adding, no particular order:
     # - boundary/boundaries, see gm.model.getBoundary()
     # - bounding_box, see gm.model.getBoundingBox()

--- a/src/pydrex/mesh.py
+++ b/src/pydrex/mesh.py
@@ -53,7 +53,7 @@ class Model:
 
     def __post_init__(self):
         for k, v in self.__dataclass_fields__.items():
-            if v.type is not type(v.default_value):
+            if v.type is not type(v.default):
                 raise ValueError(f"Illegal type for {self.__class__.__qualname__}.{k}")
 
     # TODO: Possible attributes worth adding, no particular order:

--- a/src/pydrex/mesh.py
+++ b/src/pydrex/mesh.py
@@ -51,14 +51,10 @@ class Model:
     _write_file: bool = True
     _was_entered: bool = False
 
-    @classmethod
-    def __check_type__(cls, field, value):
-        if not isinstance(value, type(getattr(cls, field))):
-            raise ValueError(f"Illegal type for {cls.__qualname__}.{field}")
-
     def __post_init__(self):
-        for k, v in self.__dict__.items():
-            self.__check_type__(k, v)
+        for k, v in self.__dataclass_fields__.items():
+            if v.type is not type(v.default_value):
+                raise ValueError(f"Illegal type for {self.__class__.__qualname__}.{k}")
 
     # TODO: Possible attributes worth adding, no particular order:
     # - boundary/boundaries, see gm.model.getBoundary()

--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -51,6 +51,14 @@ returned by `pydrex.core.get_crss`.
 
 @dataclass
 class StiffnessTensors:
+    """Stiffness tensors (Voigt representation), with units of GPa.
+
+    The source of the values used here is unknown, but they are copied
+    from the original DRex code: <http://www.ipgp.fr/~kaminski/web_doudoud/DRex.tar.gz>
+    [88K download]
+
+    """
+
     olivine: np.ndarray = field(
         default_factory=lambda: np.array(
             [
@@ -63,13 +71,6 @@ class StiffnessTensors:
             ]
         )
     )
-    """Stiffness tensor for olivine (Voigt representation), with units of GPa.
-
-    The source of the values used here is unknown, but they are copied
-    from the original DRex code: <http://www.ipgp.fr/~kaminski/web_doudoud/DRex.tar.gz>
-    [88K download]
-
-    """
     enstatite: np.ndarray = field(
         default_factory=lambda: np.array(
             [
@@ -82,13 +83,6 @@ class StiffnessTensors:
             ]
         )
     )
-    """Stiffness tensor for enstatite (Voigt representation), with units of GPa.
-
-    The source of the values used here is unknown, but they are copied
-    from the original DRex code: <http://www.ipgp.fr/~kaminski/web_doudoud/DRex.tar.gz>
-    [88K download]
-
-    """
 
     def __iter__(self):
         # So that [S for S in StiffnessTensors()] can be indexed with `MineralPhase`s.
@@ -98,6 +92,15 @@ class StiffnessTensors:
         }
         for _, v in sorted(indexed.items()):
             yield v
+
+    @classmethod
+    def __check_type__(cls, field, value):
+        if not isinstance(value, type(getattr(cls, field))):
+            raise ValueError(f"Illegal type for {cls.__qualname__}.{field}")
+
+    def __post_init__(self):
+        for k, v in self.__dict__.items():
+            self.__check_type__(k, v)
 
 
 def peridotite_solidus(pressure, fit="Hirschmann2000"):

--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -95,7 +95,7 @@ class StiffnessTensors:
 
     def __post_init__(self):
         for k, v in self.__dataclass_fields__.items():
-            if v.type is not type(v.default_value):
+            if v.type is not type(v.default):
                 raise ValueError(f"Illegal type for {self.__class__.__qualname__}.{k}")
 
 

--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -95,7 +95,7 @@ class StiffnessTensors:
 
     def __post_init__(self):
         for k, v in self.__dataclass_fields__.items():
-            if v.type is not type(v.default):
+            if v.type is not type(v.default_factory()):
                 raise ValueError(f"Illegal type for {self.__class__.__qualname__}.{k}")
 
 

--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -93,14 +93,10 @@ class StiffnessTensors:
         for _, v in sorted(indexed.items()):
             yield v
 
-    @classmethod
-    def __check_type__(cls, field, value):
-        if not isinstance(value, type(getattr(cls, field))):
-            raise ValueError(f"Illegal type for {cls.__qualname__}.{field}")
-
     def __post_init__(self):
-        for k, v in self.__dict__.items():
-            self.__check_type__(k, v)
+        for k, v in self.__dataclass_fields__.items():
+            if v.type is not type(v.default_value):
+                raise ValueError(f"Illegal type for {self.__class__.__qualname__}.{k}")
 
 
 def peridotite_solidus(pressure, fit="Hirschmann2000"):

--- a/src/pydrex/mock.py
+++ b/src/pydrex/mock.py
@@ -1,107 +1,115 @@
 """> PyDRex: Mock objects for testing and reproducibility."""
 
-from pydrex.core import MineralFabric, MineralPhase
+from pydrex.core import DefaultParams, MineralFabric, MineralPhase
 
-PARAMS_FRATERS2021 = {
-    "phase_assemblage": (MineralPhase.olivine, MineralPhase.enstatite),
-    "phase_fractions": (0.7, 0.3),
-    "initial_olivine_fabric": MineralFabric.olivine_A,
-    "stress_exponent": 1.5,
-    "deformation_exponent": 3.5,
-    "gbm_mobility": 125,
-    "gbs_threshold": 0.3,
-    "nucleation_efficiency": 5,
-    "number_of_grains": 5000,
-}
-"""Values used for tests 1, 2 and 4 in <https://doi.org/10.1029/2021gc009846>."""
 
-PARAMS_KAMINSKI2001_FIG5_SOLID = {
-    "phase_assemblage": (MineralPhase.olivine,),
-    "phase_fractions": (1,),
-    "initial_olivine_fabric": MineralFabric.olivine_A,
-    "stress_exponent": 1.5,
-    "deformation_exponent": 3.5,
-    "gbm_mobility": 0,
-    "gbs_threshold": 0,
-    "nucleation_efficiency": 5,
-    "number_of_grains": 3375,  # 15^3 as in the Fortran code.
-}
-"""Values used for the M*=0 test in <https://doi.org/10.1016/s0012-821x(01)00356-9>."""
+class ParamsFraters2021(DefaultParams):
+    """Values used for tests 1, 2 and 4 in <https://doi.org/10.1029/2021gc009846>."""
 
-PARAMS_KAMINSKI2001_FIG5_SHORTDASH = {
-    "phase_assemblage": (MineralPhase.olivine,),
-    "phase_fractions": (1,),
-    "initial_olivine_fabric": MineralFabric.olivine_A,
-    "stress_exponent": 1.5,
-    "deformation_exponent": 3.5,
-    "gbm_mobility": 50,
-    "gbs_threshold": 0,
-    "nucleation_efficiency": 5,
-    "number_of_grains": 3375,  # 15^3 as in the Fortran code.
-}
-"""Values used for the M*=50 test in <https://doi.org/10.1016/s0012-821x(01)00356-9>."""
+    phase_assemblage = (MineralPhase.olivine, MineralPhase.enstatite)
+    phase_fractions = (0.7, 0.3)
+    initial_olivine_fabric = MineralFabric.olivine_A
+    stress_exponent = 1.5
+    deformation_exponent = 3.5
+    gbm_mobility = 125
+    gbs_threshold = 0.3
+    nucleation_efficiency = 5.0
+    number_of_grains = 5000
 
-PARAMS_KAMINSKI2001_FIG5_LONGDASH = {
-    "phase_assemblage": (MineralPhase.olivine,),
-    "phase_fractions": (1,),
-    "initial_olivine_fabric": MineralFabric.olivine_A,
-    "stress_exponent": 1.5,
-    "deformation_exponent": 3.5,
-    "gbm_mobility": 200,
-    "gbs_threshold": 0,
-    "nucleation_efficiency": 5,
-    "number_of_grains": 3375,  # 15^3 as in the Fortran code.
-}
-"""Values used for the M*=200 test in <https://doi.org/10.1016/s0012-821x(01)00356-9>."""
 
-PARAMS_KAMINSKI2004_FIG4_TRIANGLES = {
-    "phase_assemblage": (MineralPhase.olivine,),
-    "phase_fractions": (1,),
-    "initial_olivine_fabric": MineralFabric.olivine_A,
-    "stress_exponent": 1.5,
-    "deformation_exponent": 3.5,
-    "gbm_mobility": 125,
-    "gbs_threshold": 0.4,
-    "nucleation_efficiency": 5,
-    "number_of_grains": 4394,  # Section 4.1, first paragraph.
-}
-"""Values used for the χ=0.4 test in <https://doi.org/10.1111/j.1365-246x.2004.02308.x>."""
+class ParamsKaminski2001_Fig5Solid(DefaultParams):
+    """Values used for the M*=0 test in <https://doi.org/10.1016/s0012-821x(01)00356-9>."""
 
-PARAMS_KAMINSKI2004_FIG4_SQUARES = {
-    "phase_assemblage": (MineralPhase.olivine,),
-    "phase_fractions": (1,),
-    "initial_olivine_fabric": MineralFabric.olivine_A,
-    "stress_exponent": 1.5,
-    "deformation_exponent": 3.5,
-    "gbm_mobility": 125,
-    "gbs_threshold": 0.2,
-    "nucleation_efficiency": 5,
-    "number_of_grains": 4394,  # Section 4.1, first paragraph.
-}
-"""Values used for the χ=0.2 test in <https://doi.org/10.1111/j.1365-246x.2004.02308.x>."""
+    phase_assemblage = (MineralPhase.olivine,)
+    phase_fractions = (1,)
+    initial_olivine_fabric = MineralFabric.olivine_A
+    stress_exponent = 1.5
+    deformation_exponent = 3.5
+    gbm_mobility = 0
+    gbs_threshold = 0
+    nucleation_efficiency = 5
+    number_of_grains = 3375  # 15^3 as in the Fortran code.
 
-PARAMS_KAMINSKI2004_FIG4_CIRCLES = {
-    "phase_assemblage": (MineralPhase.olivine,),
-    "phase_fractions": (1,),
-    "initial_olivine_fabric": MineralFabric.olivine_A,
-    "stress_exponent": 1.5,
-    "deformation_exponent": 3.5,
-    "gbm_mobility": 125,
-    "gbs_threshold": 0,
-    "nucleation_efficiency": 5,
-    "number_of_grains": 4394,  # Section 4.1, first paragraph.
-}
-"""Values used for the χ=0 test in <https://doi.org/10.1111/j.1365-246x.2004.02308.x>."""
 
-PARAMS_HEDJAZIAN2017 = {
-    "phase_assemblage": (MineralPhase.olivine, MineralPhase.enstatite),
-    "phase_fractions": (0.7, 0.3),
-    "initial_olivine_fabric": MineralFabric.olivine_A,
-    "stress_exponent": 1.5,
-    "deformation_exponent": 3.5,
-    "gbm_mobility": 10,
-    "gbs_threshold": 0.2,
-    "nucleation_efficiency": 5,
-    "number_of_grains": 2197,  # 13^3 for both olivine and enstatite.
-}
-"""Values used for the MOR model in <https://doi.org/10.1016/j.epsl.2016.12.004>."""
+class ParamsKaminski2001_Fig5ShortDash(DefaultParams):
+    """Values used for the M*=50 test in <https://doi.org/10.1016/s0012-821x(01)00356-9>."""
+
+    phase_assemblage = (MineralPhase.olivine,)
+    phase_fractions = (1,)
+    initial_olivine_fabric = MineralFabric.olivine_A
+    stress_exponent = 1.5
+    deformation_exponent = 3.5
+    gbm_mobility = 50
+    gbs_threshold = 0
+    nucleation_efficiency = 5
+    number_of_grains = 3375  # 15^3 as in the Fortran code.
+
+
+class ParamsKaminski2001_Fig5LongDash(DefaultParams):
+    """Values used for the M*=200 test in <https://doi.org/10.1016/s0012-821x(01)00356-9>"""
+
+    phase_assemblage = (MineralPhase.olivine,)
+    phase_fractions = (1,)
+    initial_olivine_fabric = MineralFabric.olivine_A
+    stress_exponent = 1.5
+    deformation_exponent = 3.5
+    gbm_mobility = 200
+    gbs_threshold = 0
+    nucleation_efficiency = 5
+    number_of_grains = 3375  # 15^3 as in the Fortran code.
+
+
+class ParamsKaminski2004_Fig4Triangles(DefaultParams):
+    """Values used for the χ=0.4 test in <https://doi.org/10.1111/j.1365-246x.2004.02308.x>."""
+
+    phase_assemblage = (MineralPhase.olivine,)
+    phase_fractions = (1,)
+    initial_olivine_fabric = MineralFabric.olivine_A
+    stress_exponent = 1.5
+    deformation_exponent = 3.5
+    gbm_mobility = 125
+    gbs_threshold = 0.4
+    nucleation_efficiency = 5
+    number_of_grains = 4394  # Section 4.1, first paragraph.
+
+
+class ParamsKaminski2004_Fig4Squares(DefaultParams):
+    """Values used for the χ=0.2 test in <https://doi.org/10.1111/j.1365-246x.2004.02308.x>."""
+
+    phase_assemblage = (MineralPhase.olivine,)
+    phase_fractions = (1,)
+    initial_olivine_fabric = MineralFabric.olivine_A
+    stress_exponent = 1.5
+    deformation_exponent = 3.5
+    gbm_mobility = 125
+    gbs_threshold = 0.2
+    nucleation_efficiency = 5
+    number_of_grains = 4394  # Section 4.1, first paragraph.
+
+
+class ParamsKaminski2004_Fig4Circles(DefaultParams):
+    """Values used for the χ=0 test in <https://doi.org/10.1111/j.1365-246x.2004.02308.x>."""
+
+    phase_assemblage = (MineralPhase.olivine,)
+    phase_fractions = (1,)
+    initial_olivine_fabric = MineralFabric.olivine_A
+    stress_exponent = 1.5
+    deformation_exponent = 3.5
+    gbm_mobility = 125
+    gbs_threshold = 0
+    nucleation_efficiency = 5
+    number_of_grains = 4394  # Section 4.1, first paragraph.
+
+
+class ParamsHedjazian2017(DefaultParams):
+    """Values used for the MOR model in <https://doi.org/10.1016/j.epsl.2016.12.004>."""
+
+    phase_assemblage = (MineralPhase.olivine, MineralPhase.enstatite)
+    phase_fractions = (0.7, 0.3)
+    initial_olivine_fabric = MineralFabric.olivine_A
+    stress_exponent = 1.5
+    deformation_exponent = 3.5
+    gbm_mobility = 10
+    gbs_threshold = 0.2
+    nucleation_efficiency = 5
+    number_of_grains = 2197  # 13^3 for both olivine and enstatite.

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,8 +4,9 @@ Running the base test suite requires [pytest](https://docs.pytest.org) and up to
 By default, `make test` will attempt to write persistent logs and output to `./out/`.
 
 Alternatively, run `pytest` from the root of the source tree.
-To print more verbose information (including INFO level logging),
-such as detailed test progress, use the flag `pytest -v`.
+To print more verbose test progress and information, use the flag `pytest -v`.
+Passing the verbose flag a second time (`pytest -vv`)
+additionally shows verbose output from doctests.
 The custom optional flag `--outdir="OUT"` is recommended
 to produce output figures, data dumps and logs and save them in the directory `"OUT"`.
 The value `"."` can be used to save these in the current directory.
@@ -26,6 +27,11 @@ In total, the following custom pytest command line flags are defined by PyDRex:
 - `--markersize` (Matplotlib `rcParams["lines.markersize"]`)
 - `--linewidth` (Matplotlib `rcParams["lines.linewidth"]`)
 
+The following pytest command line flags are disabled by PyDRex:
+- `--log-cli-format` and `--log-cli-date-format`
+- `--log-file` and associated options (use `--outdir` instead)
+- `--capture=<method>`, where `<method>` is anything except `fd`
+
 Tests which require a “significant” amount of memory (> ~16GB RAM) are disabled by default.
 To fully check the functionality of the code, it is recommended to run these locally
 by using the `--runbig` flag before moving to larger simulations.
@@ -38,6 +44,8 @@ The number of cores to use for shared memory multiprocessing can be specified wi
 
 For quick sanity checks and inline unit tests, use [python doctests](https://docs.python.org/3/library/doctest.html).
 These will also appear as inline examples in the generated documentation.
+Doctests may safely assume a live console logging level of `INFO`,
+regardless of any user-supplied pytest command line flags.
 More comprehensive unit tests and larger integration tests should be organised
 into submodules of the `test` module.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 """> Configuration and fixtures for PyDRex tests."""
 
 import argparse
-import sys
 
 import matplotlib
 import numpy as np
@@ -175,14 +174,6 @@ def ncpus(request):
 
 
 @pytest.fixture(scope="session")
-def named_tempfile_kwargs(request):
-    if sys.platform == "win32":
-        return {"delete": False}
-    else:
-        return {}
-
-
-@pytest.fixture(scope="session")
 def ray_session():
     if HAS_RAY:
         # NOTE: Expects a running Ray cluster with a number of CPUS matching --ncpus.
@@ -195,9 +186,16 @@ def ray_session():
     yield
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def console_handler(request):
-    if request.config.option.verbose > 0:  # Show console logs if -v/--verbose given.
+    """Return the live logging handler for pydrex.
+
+    If `-v`/`--verbose` is passed to the pytest command,
+    this returns the handler of the 'pydrex-live-logger' pytest plugin.
+    Otherwise, returns the default pydrex CLI logging handler.
+
+    """
+    if request.config.option.verbose > 0:
         return request.config.pluginmanager.get_plugin(
             "pydrex-live-logger"
         ).log_cli_handler

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,43 +205,8 @@ def console_handler(request):
 
 
 @pytest.fixture
-def params_Fraters2021():
-    return _mock.PARAMS_FRATERS2021
-
-
-@pytest.fixture
-def params_Kaminski2001_fig5_solid():
-    return _mock.PARAMS_KAMINSKI2001_FIG5_SOLID
-
-
-@pytest.fixture
-def params_Kaminski2001_fig5_shortdash():
-    return _mock.PARAMS_KAMINSKI2001_FIG5_SHORTDASH
-
-
-@pytest.fixture
-def params_Kaminski2001_fig5_longdash():
-    return _mock.PARAMS_KAMINSKI2001_FIG5_LONGDASH
-
-
-@pytest.fixture
-def params_Kaminski2004_fig4_triangles():
-    return _mock.PARAMS_KAMINSKI2004_FIG4_TRIANGLES
-
-
-@pytest.fixture
-def params_Kaminski2004_fig4_squares():
-    return _mock.PARAMS_KAMINSKI2004_FIG4_SQUARES
-
-
-@pytest.fixture
-def params_Kaminski2004_fig4_circles():
-    return _mock.PARAMS_KAMINSKI2004_FIG4_CIRCLES
-
-
-@pytest.fixture
-def params_Hedjazian2017():
-    return _mock.PARAMS_HEDJAZIAN2017
+def mock():
+    return _mock
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,6 @@ def pytest_configure(config):
 
     # Hook up our logging plugin last,
     # it relies on terminalreporter and capturemanager.
-    # Because the log_cli=true init option is not introspectable, we use -v instead.
     # To subclass the logging plugin we also had to break --capture except for -s
     # (--capture=no), so bail if the user tries to set --capture=method.
     if config.option.log_cli_level is not None:
@@ -132,7 +131,7 @@ def pytest_configure(config):
                 + "use --capture=fd"
             ),
         ) from None
-    if config.option.verbose > 0:
+    if config.option.verbose > 0 or config.getini("log_cli"):
         config.pluginmanager.register(PyDRexLiveLogger(config), PyDRexLiveLogger.name)
 
 
@@ -157,6 +156,8 @@ def pytest_collection_modifyitems(config, items):
 
 @pytest.fixture(scope="session")
 def verbose(request):
+    if request.config.option.verbose == 0 and request.config.getini("log_cli"):
+        return 1
     return request.config.option.verbose
 
 
@@ -195,7 +196,7 @@ def console_handler(request):
     Otherwise, returns the default pydrex CLI logging handler.
 
     """
-    if request.config.option.verbose > 0:
+    if request.config.option.verbose > 0 or request.config.getini("log_cli"):
         return request.config.pluginmanager.get_plugin(
             "pydrex-live-logger"
         ).log_cli_handler

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -28,46 +28,48 @@ def _get_submodule_list():
 @pytest.mark.parametrize("module", _get_submodule_list())
 def test_doctests(module, capsys, verbose):
     """Run doctests for all submodules."""
-    with capsys.disabled():  # Pytest output capturing messes with doctests.
-        _log.info("running doctests for %s...", module)
-        try:
-            n_fails, n_tests = doctest.testmod(
-                importlib.import_module(module),
-                raise_on_error=True,
-                verbose=verbose > 1,  # Run pytest with -vv to show doctest details.
-            )
-            if n_fails > 0:
+    with pydrex.io.log_cli_level("INFO"):  # Doctests can expect INFO level logging.
+        with capsys.disabled():  # sys.std{out,err} capturing messes with doctests.
+            _log.info("running doctests for %s...", module)
+            try:
+                n_fails, n_tests = doctest.testmod(
+                    importlib.import_module(module),
+                    raise_on_error=True,
+                    verbose=verbose > 1,  # Run pytest with -vv to show doctest details.
+                )
+                if n_fails > 0:
+                    raise AssertionError(
+                        f"there were {n_fails} doctest failures from {module}"
+                    )
+            except doctest.DocTestFailure as e:
+                if e.test.lineno is None:
+                    lineno = ""
+                else:
+                    lineno = f":{e.test.lineno + 1 + e.example.lineno}"
                 raise AssertionError(
-                    f"there were {n_fails} doctest failures from {module}"
-                )
-        except doctest.DocTestFailure as e:
-            if e.test.lineno is None:
-                lineno = ""
-            else:
-                lineno = f":{e.test.lineno + 1 + e.example.lineno}"
-            raise AssertionError(
-                f"{e.test.name} ({module}{lineno}) failed with:"
-                + os.linesep
-                + os.linesep
-                + e.got
-            ) from None
-        except doctest.UnexpectedException as e:
-            if e.test.lineno is None:
-                lineno = ""
-            else:
-                lineno = f":{e.test.lineno + 1 + e.example.lineno}"
-            err_type, err, _ = e.exc_info
-            if err_type is NameError:  # Raised on missing optional functions.
-                # Issue warning but let the test suite pass.
-                _log.warning(
-                    "skipping doctest of missing optional symbol in %s", module
-                )
-            elif err_type is np.core._exceptions._ArrayMemoryError:
-                # Faiures to allocate should not be fatal to the doctest test suite.
-                _log.warning(
-                    "skipping doctests for module %s due to insufficient memory", module
-                )
-            else:
-                raise Error(
-                    f"{err_type.__qualname__} encountered in {e.test.name} ({module}{lineno})"
-                ) from err
+                    f"{e.test.name} ({module}{lineno}) failed with:"
+                    + os.linesep
+                    + os.linesep
+                    + e.got
+                ) from None
+            except doctest.UnexpectedException as e:
+                if e.test.lineno is None:
+                    lineno = ""
+                else:
+                    lineno = f":{e.test.lineno + 1 + e.example.lineno}"
+                err_type, err, _ = e.exc_info
+                if err_type is NameError:  # Raised on missing optional functions.
+                    # Issue warning but let the test suite pass.
+                    _log.warning(
+                        "skipping doctest of missing optional symbol in %s", module
+                    )
+                elif err_type is np.core._exceptions._ArrayMemoryError:
+                    # Faiures to allocate should not be fatal to the doctest test suite.
+                    _log.warning(
+                        "skipping doctests for module %s due to insufficient memory",
+                        module,
+                    )
+                else:
+                    raise Error(
+                        f"{err_type.__qualname__} encountered in {e.test.name} ({module}{lineno})"
+                    ) from err

--- a/tests/test_scsv.py
+++ b/tests/test_scsv.py
@@ -46,7 +46,7 @@ def test_validate_schema(console_handler):
 
     # NOTE: NamedTemporaryFile() already opens the file.
     # Attempting to open it again will cause a crash on Windows so close the file first.
-    with _log.handler_level("CRITICAL", console_handler):
+    with _io.log_cli_level("CRITICAL", console_handler):
         with pytest.raises(_err.SCSVError):
             temp = tempfile.NamedTemporaryFile()
             temp.close()

--- a/tests/test_scsv.py
+++ b/tests/test_scsv.py
@@ -6,7 +6,6 @@ from numpy import testing as nt
 from pydrex import exceptions as _err
 from pydrex import io as _io
 from pydrex import logger as _log
-from pydrex import utils as _utils
 
 
 def test_validate_schema(tmp_path, console_handler):

--- a/tests/test_scsv.py
+++ b/tests/test_scsv.py
@@ -86,7 +86,6 @@ def test_read_specfile():
     nt.assert_equal(data.complex_column, [0.1 + 0 * 1j, np.nan + 0 * 1j, 1.0 + 1 * 1j])
 
 
-@pytest.mark.skipif(_utils.in_ci("win32"), reason="Items are not equal")
 def test_save_specfile(tmp_path, outdir):
     """Test SCSV spec file reproduction."""
     schema = {
@@ -153,9 +152,10 @@ def test_save_specfile(tmp_path, outdir):
     raw_read = []
     raw_read_alt = []
     with open(temp) as stream:
-        raw_read = stream.readlines()[23:]  # Extra spec for first column 'fill' value.
+        # Extra spec for first column 'fill' value.
+        raw_read = list(filter(None, stream.read().splitlines()))[23:]
     with open(temp_alt) as stream:
-        raw_read_alt = stream.readlines()[22:]
+        raw_read_alt = list(filter(None, stream.read().splitlines()))[22:]
     _log.debug("\n  first file: %s\n  second file: %s", raw_read, raw_read_alt)
     nt.assert_equal(raw_read, raw_read_alt)
 

--- a/tests/test_simple_shear_3d.py
+++ b/tests/test_simple_shear_3d.py
@@ -54,7 +54,7 @@ class TestFraters2021:
         Other keyword args are passed to `pydrex.Mineral.update_orientations`.
 
         Returns a tuple containing one olivine (A-type) and one enstatite mineral.
-        If `params["enstatite_fraction"]` is zero, then the second tuple element will be
+        If `params.enstatite_fraction` is zero, then the second tuple element will be
         `None` instead.
 
         """
@@ -66,15 +66,15 @@ class TestFraters2021:
             phase=_core.MineralPhase.olivine,
             fabric=_core.MineralFabric.olivine_A,
             regime=_core.DeformationRegime.matrix_dislocation,
-            n_grains=params["number_of_grains"],
+            n_grains=params.number_of_grains,
             seed=seed,
         )
-        if params["enstatite_fraction"] > 0:
+        if params.enstatite_fraction > 0:
             enstatite = _minerals.Mineral(
                 phase=_core.MineralPhase.enstatite,
                 fabric=_core.MineralFabric.enstatite_AB,
                 regime=_core.DeformationRegime.matrix_dislocation,
-                n_grains=params["number_of_grains"],
+                n_grains=params.number_of_grains,
                 seed=seed,
             )
         else:
@@ -90,7 +90,7 @@ class TestFraters2021:
             else:
                 get_velocity_gradient = get_velocity_gradient_initial
 
-            if params["enstatite_fraction"] > 0:
+            if params.enstatite_fraction > 0:
                 enstatite.update_orientations(
                     params,
                     deformation_gradient,
@@ -112,7 +112,7 @@ class TestFraters2021:
     @pytest.mark.slow
     @pytest.mark.parametrize("switch_time_Ma", [0, 1, 2.5, np.inf])
     def test_direction_change(
-        self, outdir, seeds, params_Fraters2021, switch_time_Ma, ncpus, ray_session
+        self, outdir, seeds, mock, switch_time_Ma, ncpus, ray_session
     ):
         """Test a-axis alignment in simple shear with instantaneous geometry change.
 
@@ -159,7 +159,7 @@ class TestFraters2021:
             clock_start = process_time()
             _run = ft.partial(
                 self.run,
-                params_Fraters2021,
+                mock.ParamsFraters2021(),
                 timestamps,
                 get_velocity_gradient_initial,
                 get_velocity_gradient_final,


### PR DESCRIPTION
- Some changes to logging, sending some symbols to `pydrex.io` instead
- Changes to `pydrex.logger` documentation, recommending use of `logging.getLogger("pydrex")` for users (which will not mess with their numpy printoptions)
- more robust pytest live logging plugin and setup, with early errors if the couple of problematic pytest command line options are discovered (and collapsing `-v` and `log_cli=true` into the same behaviour)
- type validation during construction of some dataclasses
- `live_docs` make target, allows browsing up to date documentation while editing
- closes #211 

No `QueueHandler` for multiprocessing just yet.