### PR TITLE
Improve default LSODA tolerances

### DIFF
--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -520,7 +520,7 @@ class Mineral:
             time_start,
             y_start,
             time_end,
-            atol=kwargs.pop("atol", np.abs(y_start * 1e-6) + 1e-12),
+            atol=kwargs.pop("atol", np.abs(y_start * 1e-6) + 1e-4),
             rtol=kwargs.pop("rtol", 1e-6),
             first_step=kwargs.pop("first_step", np.abs(time_end - time_start) * 1e-1),
             # max_step=kwargs.pop("max_step", np.abs(time_end - time_start)),


### PR DESCRIPTION
Loosening the `atol` tolerance for the main LSODA solver improves performance significantly without failing any of our tests. Because we already modify `atol` based on the initial condition, this change mostly just prevents LSODA from trying to meet unreasonably tight error tolerances for those elements of the solution where the corresponding initial condition is zero. With this improvement we go from being sometimes more than 20x slower than the Fortran (for simple shear, excluding Numba compilation time) to being about 7 or 8 times slower.