### PR TITLE
Avoid zero-division under uniaxial compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Handling of enstatite in Voigt averaging
 - Handling of optional keyword args in some visualisation functions
+- Zero-division error for some grain orientations under uniaxial compression
 
 ### Removed
 - Access to `io` symbols in global `pydrex` namespace (use `pydrex.io` instead)

--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -714,6 +714,12 @@ def _get_rotation_and_strain(
     """
     crss = get_crss(phase, fabric)
     slip_invariants = _get_slip_invariants(strain_rate, orientation)
+    # Handle the case where all slip invariants are zero,
+    # thus no slip is possible (occurs for a few specific orientations and strain rates,
+    # for example in the case of uniaxial compression and an identity orientation
+    # i.e. grain orientation aligned to the coordinate system).
+    if np.all(slip_invariants == 0):
+        return np.zeros((3, 3)), 0.0
     if phase == MineralPhase.olivine:
         slip_indices = np.argsort(np.abs(slip_invariants / crss))
         slip_rates = _get_slip_rates_olivine(


### PR DESCRIPTION
This fixes a zero-division for some orientations under uniaxial compression, by catching the problematic values for slip invariants and returning null-values for orientation change and grain growth. There are some conditions where slip is simply not possible at all, and it is worth adding this check even though most Real World Problems are unlikely to hit this issue (strain rates would normally have pure shear, simple shear and compressional components combined).