### PR TITLE
Maintenance tasks related to system and software upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
   install-macos:
     name: (MacOS) Install package and run tests
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     strategy:
       matrix:
         python-version: ['3.11', '3.12', '3.13']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
   install-macos:
     name: (MacOS) Install package and run tests
-    runs-on: macos-latest-large
+    runs-on: macos-15-intel
     strategy:
       matrix:
         python-version: ['3.11', '3.12', '3.13']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - Patol75/bump_ci
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
   install-windows:
     name: (Windows) Install package and run tests
-    runs-on: windows-latest
+    runs-on: windows-2025
     strategy:
       matrix:
         python-version: ['3.11', '3.12', '3.13']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - Patol75/bump_ci
   pull_request:
     branches:
       - main
@@ -14,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -39,14 +40,14 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -61,14 +62,14 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:  # Always attempt html build on push & PR, but only deploy when there is a n
   push:
     branches:
       - main
+      - Patol75/bump_ci
     tags:
       - v*
   pull_request:
@@ -21,15 +22,17 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.13'
+
+      - name: Setup Just
+        uses: extractions/setup-just@v3
 
       - name: Build
-        uses: extractions/setup-just@v1
         run: |
           sudo apt-get update
           sudo apt-get install -y python3-pip

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,6 @@ on:  # Always attempt html build on push & PR, but only deploy when there is a n
   push:
     branches:
       - main
-      - Patol75/bump_ci
     tags:
       - v*
   pull_request:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 # Use modern (PEP621, PEP660) setuptools build system.
 # PEP 660 editable installs: <https://github.com/pypa/setuptools/blob/main/NEWS.rst#v6400>.
-# Python 3.11 support: <https://github.com/pypa/setuptools_scm/blob/main/CHANGELOG.md#v710>.
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm[toml]>=8"]
+requires = ["setuptools>=80", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 # Automatically use the version number from vcs (e.g. git) tags,
@@ -15,7 +14,7 @@ name = "pydrex"
 dynamic = ["version"]  # Managed by setuptools_scm.
 description = "Dynamic CPO calculations for olivine-enstatite polycrystal aggregates"
 readme = "README.md"
-requires-python = ">=3.10"  # We use tomllib on 3.11: <https://docs.python.org/3/library/tomllib.html>.
+requires-python = ">=3.11"
 license = {file = "LICENSE"}
 authors = [
     {name = "Thomas Duvernay", email = "td75013@hotmail.fr"},
@@ -32,7 +31,6 @@ classifiers = [  # List of possible classifiers: <https://pypi.org/classifiers/>
 ]
 
 dependencies = [
-    "tomli >= 1.1.0 ; python_version < '3.11'",  # https://github.com/hukkin/tomli?tab=readme-ov-file#building-a-tomlitomllib-compatibility-layer
     "numpy >= 1.8",  # <https://numpy.org/doc/stable/reference/generated/numpy.linalg.eigvalsh.html>
     "numba >= 0.57",  # <https://numba.readthedocs.io/en/stable/release-notes.html#version-0-57-0-1-may-2023>
     "scipy >= 1.2",  # <https://github.com/scipy/scipy/pull/9176>
@@ -48,7 +46,7 @@ dependencies = [
 [project.optional-dependencies]
 # These optional dependencies are relevant for built distributions (e.g. via pip):
 mesh = ["gmsh"]  # Required for pydrex-mesh, doesn't play nice with CI.
-ray = ["ray >= 2.0.0"]  # Required for distributed-memory examples.
+ray = ["ray[default] >= 2.0.0"]  # Required for distributed-memory examples.
 # These optional dependencies are only relevant for source distributions:
 test = ["pytest"]  # Minimal test dependencies, for CI.
 doc = ["pdoc", "setuptools-scm"]  # Minimal html docs dependencies, for CI.

--- a/src/pydrex/io.py
+++ b/src/pydrex/io.py
@@ -24,12 +24,7 @@ import os
 import pathlib
 import re
 import sys
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
-
+import tomllib
 from importlib.resources import files
 
 import h5py

--- a/src/pydrex/mesh.py
+++ b/src/pydrex/mesh.py
@@ -53,7 +53,7 @@ class Model:
 
     def __post_init__(self):
         for k, v in self.__dataclass_fields__.items():
-            if v.type is not type(v.default):
+            if v.type is not self.__annotations__[k]:
                 raise ValueError(f"Illegal type for {self.__class__.__qualname__}.{k}")
 
     # TODO: Possible attributes worth adding, no particular order:
@@ -195,7 +195,7 @@ def rectangle(
     >>> rect.loop_tags
     [1]
     >>> [p[-1] for p in rect.point_constraints]
-    [0.01, 0.01, 0.01, 0.01]
+    [np.float64(0.01), np.float64(0.01), np.float64(0.01), np.float64(0.01)]
 
     >>> rect = rectangle(
     ...     "test_rect",
@@ -207,7 +207,7 @@ def rectangle(
     ...     _write_file=False
     ... )
     >>> [p[-1] for p in rect.point_constraints]
-    [0.001, 0.001, 0.01, 0.01]
+    [np.float64(0.001), np.float64(0.001), np.float64(0.01), np.float64(0.01)]
 
     >>> rect = rectangle(
     ...     "test_rect",
@@ -219,13 +219,13 @@ def rectangle(
     ...     _write_file=False
     ... )
     >>> rect.point_constraints[1][-1]
-    0.01
+    np.float64(0.01)
     >>> rect.point_constraints[3][-1]
-    0.001
+    np.float64(0.001)
     >>> rect.point_constraints[0][-1] == rect.point_constraints[2][-1]
-    True
+    np.True_
     >>> rect.point_constraints[0][-1]
-    0.0055
+    np.float64(0.0055)
 
     """
 

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -63,7 +63,7 @@ def test_doctests(module, capsys, verbose):
                     _log.warning(
                         "skipping doctest of missing optional symbol in %s", module
                     )
-                elif err_type is np.core._exceptions._ArrayMemoryError:
+                elif err_type is np._core._exceptions._ArrayMemoryError:
                     # Faiures to allocate should not be fatal to the doctest test suite.
                     _log.warning(
                         "skipping doctests for module %s due to insufficient memory",


### PR DESCRIPTION
In this PR, I removed maintenance for Python 3.10 and introduced testing for Python 3.13.
Additionally, I made the CI use the latest GitHub Windows runner, swapped the Arm64 version of macOS for the Intel one, and updated the versions of Actions used. 
Finally, I fixed errors and warnings raised when running the test suite with Python 3.13 and recent versions of Python packages. 